### PR TITLE
[FEAT]: updated the docs to make it better and make the prod survive the change of color theme

### DIFF
--- a/app/docs/api/page.tsx
+++ b/app/docs/api/page.tsx
@@ -175,9 +175,7 @@ export default function ApiPage() {
         is not a replacement for the authenticated integration API.
       </div>
 
-      <h2 id="guest-shortening" className={H2}>
-        <MethodBadge method="POST" />Guest shortening
-      </h2>
+      <h2 id="guest-shortening" className={H2}>Guest shortening</h2>
       <Endpoint method="POST" path="/api/guest/urls" />
       <p className={P}>
         Creates one temporary short link from the public landing page. The
@@ -212,9 +210,7 @@ export default function ApiPage() {
         converted into account links after creation.
       </p>
 
-      <h2 id="create-a-short-link" className={H2}>
-        <MethodBadge method="POST" />Create an account link
-      </h2>
+      <h2 id="create-a-short-link" className={H2}>Create an account link</h2>
       <Endpoint method="POST" path="/api/urls" />
       <FieldTable rows={[
         ['url', 'string', 'Yes', 'Absolute HTTP or HTTPS destination. The same private-network and safe-content checks used by guest shortening apply.'],
@@ -245,9 +241,7 @@ export default function ApiPage() {
         exhausted account quotas return <code className={INLINE_CODE}>403</code>.
       </p>
 
-      <h2 id="list-your-links" className={H2}>
-        <MethodBadge method="GET" />List account links
-      </h2>
+      <h2 id="list-your-links" className={H2}>List account links</h2>
       <Endpoint method="GET" path="/api/urls" />
       <FieldTable rows={[
         ['limit', 'integer', 'No', 'Page size from 1–100. Defaults to 50.'],
@@ -276,9 +270,7 @@ export default function ApiPage() {
   "offset": 0
 }`}</CodeBlock>
 
-      <h2 id="get-a-link" className={H2}>
-        <MethodBadge method="GET" />Get an account link
-      </h2>
+      <h2 id="get-a-link" className={H2}>Get an account link</h2>
       <Endpoint method="GET" path="/api/urls/{code}" />
       <p className={P}>
         Returns the complete URL record shown in the list response. Ownership
@@ -288,9 +280,7 @@ export default function ApiPage() {
       <CodeBlock label="cURL">{`curl https://lixrl.com/api/urls/launch \\
   -H "Authorization: Bearer elu_YOUR_KEY"`}</CodeBlock>
 
-      <h2 id="update-a-link" className={H2}>
-        <MethodBadge method="PATCH" />Update an account link
-      </h2>
+      <h2 id="update-a-link" className={H2}>Update an account link</h2>
       <Endpoint method="PATCH" path="/api/urls/{code}" />
       <p className={P}>Send at least one mutable field. The short code itself cannot be changed.</p>
       <FieldTable rows={[
@@ -307,9 +297,7 @@ export default function ApiPage() {
   "success": true
 }`}</CodeBlock>
 
-      <h2 id="delete-a-link" className={H2}>
-        <MethodBadge method="DELETE" />Delete an account link
-      </h2>
+      <h2 id="delete-a-link" className={H2}>Delete an account link</h2>
       <Endpoint method="DELETE" path="/api/urls/{code}" />
       <p className={P}>
         Permanently removes the link and its click records. This operation is

--- a/app/docs/api/page.tsx
+++ b/app/docs/api/page.tsx
@@ -1,30 +1,131 @@
-'use client';
+import Link from 'next/link';
+import type { CSSProperties, ReactNode } from 'react';
 
-const H1 = 'text-[2.1rem] md:text-[2.4rem] font-extrabold tracking-tight text-white mb-4 leading-tight';
-const LEDE = 'text-white/70 text-base md:text-[1.05rem] leading-relaxed mb-8';
-const H2 = 'text-[1.4rem] font-bold text-white tracking-tight mt-12 mb-3';
-const P = 'text-white/70 text-[0.96rem] leading-relaxed mb-4';
-const PRE = 'p-4 rounded-xl text-[0.85rem] leading-relaxed overflow-x-auto mb-4 font-mono';
-const PRE_STYLE = {
-  background: 'rgba(0,0,0,0.45)',
-  border: '1px solid rgba(0,0,0,0.08)',
-  color: '#e8e8ed',
+const H1 =
+  'text-[2.1rem] md:text-[2.4rem] font-extrabold tracking-tight text-[#111] mb-4 leading-tight';
+const LEDE =
+  'text-[#555] text-base md:text-[1.05rem] leading-relaxed mb-8 max-w-4xl';
+const H2 =
+  'text-[1.4rem] font-bold text-[#111] tracking-tight mt-12 mb-3 scroll-mt-24';
+const H3 =
+  'text-[1.05rem] font-bold text-[#222] tracking-tight mt-7 mb-2 scroll-mt-24';
+const P = 'text-[#555] text-[0.96rem] leading-relaxed mb-4';
+const INLINE_CODE =
+  'font-mono text-[0.88em] text-[#9f211e] bg-[#fff1f0] border border-[#ffd4d1] rounded px-1.5 py-0.5';
+const PRE =
+  'p-4 md:p-5 rounded-xl text-[0.84rem] leading-[1.65] overflow-x-auto mb-5 font-mono';
+const PRE_STYLE: CSSProperties = {
+  background: '#171717',
+  border: '1px solid #2f2f2f',
+  color: '#f5f5f4',
+  boxShadow: 'inset 0 1px 0 rgba(255,255,255,0.04)',
 };
-const METHOD_STYLE: Record<string, React.CSSProperties> = {
-  POST: { background: 'rgba(229,57,53,0.18)', color: '#c62828', border: '1px solid rgba(229,57,53,0.4)' },
-  GET: { background: 'rgba(95,182,255,0.18)', color: '#bcdcff', border: '1px solid rgba(95,182,255,0.4)' },
-  PATCH: { background: 'rgba(251,191,36,0.18)', color: '#fde7a4', border: '1px solid rgba(251,191,36,0.4)' },
-  DELETE: { background: 'rgba(239,68,68,0.18)', color: '#fca5a5', border: '1px solid rgba(239,68,68,0.4)' },
+const CALLOUT_STYLE: CSSProperties = {
+  background: '#fff8f7',
+  border: '1px solid #ffd4d1',
 };
 
-function MethodBadge({ method }: { method: 'GET' | 'POST' | 'PATCH' | 'DELETE' }) {
+const METHOD_STYLE: Record<string, CSSProperties> = {
+  POST: {
+    background: '#fff1f0',
+    color: '#b42318',
+    border: '1px solid #ffc9c5',
+  },
+  GET: {
+    background: '#eaf7ff',
+    color: '#075985',
+    border: '1px solid #bae6fd',
+  },
+  PATCH: {
+    background: '#fff8db',
+    color: '#854d0e',
+    border: '1px solid #fde68a',
+  },
+  DELETE: {
+    background: '#fff0f0',
+    color: '#b91c1c',
+    border: '1px solid #fecaca',
+  },
+};
+
+type Method = 'GET' | 'POST' | 'PATCH' | 'DELETE';
+
+function MethodBadge({ method }: { method: Method }) {
   return (
     <span
-      className="inline-flex items-center px-2 py-0.5 rounded-md text-[10px] font-bold tracking-wider uppercase mr-2 font-mono"
+      data-toc-ignore
+      aria-hidden="true"
+      className="inline-flex align-middle items-center px-2 py-0.5 rounded-md text-[10px] font-bold tracking-wider uppercase mr-2 font-mono"
       style={METHOD_STYLE[method]}
     >
       {method}
     </span>
+  );
+}
+
+function CodeBlock({ children, label }: { children: string; label?: string }) {
+  return (
+    <div className="mb-5">
+      {label && (
+        <div className="mb-1.5 text-[11px] font-bold uppercase tracking-[0.08em] text-[#777]">
+          {label}
+        </div>
+      )}
+      <pre className={`${PRE} mb-0`} style={PRE_STYLE}>
+        <code>{children}</code>
+      </pre>
+    </div>
+  );
+}
+
+function FieldTable({
+  rows,
+}: {
+  rows: Array<[string, string, string, ReactNode]>;
+}) {
+  return (
+    <div className="rounded-xl overflow-x-auto mb-6 border border-[#e2e2e2]">
+      <table className="w-full min-w-[620px] text-sm">
+        <thead className="bg-[#f7f7f6] text-[#444]">
+          <tr>
+            <th className="text-left px-4 py-2.5 font-semibold">Field</th>
+            <th className="text-left px-4 py-2.5 font-semibold">Type</th>
+            <th className="text-left px-4 py-2.5 font-semibold">Required</th>
+            <th className="text-left px-4 py-2.5 font-semibold">Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map(([field, type, required, description]) => (
+            <tr key={field} className="border-t border-[#ececec] text-[#555]">
+              <td className="px-4 py-3 font-mono text-[#9f211e]">{field}</td>
+              <td className="px-4 py-3 font-mono text-[#333]">{type}</td>
+              <td className="px-4 py-3">{required}</td>
+              <td className="px-4 py-3 leading-relaxed">{description}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function Endpoint({
+  method,
+  path,
+  children,
+}: {
+  method: Method;
+  path: string;
+  children?: ReactNode;
+}) {
+  return (
+    <div className="mb-5">
+      <div className="flex flex-wrap items-center gap-2 rounded-xl border border-[#e2e2e2] bg-[#fafafa] px-4 py-3">
+        <MethodBadge method={method} />
+        <code className="font-mono text-[0.92rem] text-[#222]">{path}</code>
+      </div>
+      {children}
+    </div>
   );
 }
 
@@ -33,98 +134,231 @@ export default function ApiPage() {
     <article>
       <h1 className={H1}>Shortening API</h1>
       <p className={LEDE}>
-        The four endpoints you need to create, list, update, and delete short
-        links. Authenticate every request with an API key in the{' '}
-        <code className="font-mono text-white">Authorization</code> header.
+        Create and manage account-owned short links, or use the browser-only
+        guest flow for one temporary link. This reference documents request
+        fields, response bodies, tier restrictions, pagination, expiry, and
+        failure behavior as implemented by the edge routes.
       </p>
+
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-3 mb-10">
+        {[
+          ['Base URL', 'https://lixrl.com'],
+          ['Content type', 'application/json'],
+          ['Authentication', 'Bearer API key'],
+        ].map(([label, value]) => (
+          <div key={label} className="rounded-xl border border-[#e2e2e2] bg-[#fafafa] p-4">
+            <div className="text-[11px] font-bold uppercase tracking-wider text-[#777] mb-1">
+              {label}
+            </div>
+            <div className="font-mono text-[0.82rem] text-[#222] break-all">
+              {value}
+            </div>
+          </div>
+        ))}
+      </div>
 
       <h2 id="authentication" className={H2}>Authentication</h2>
-      <pre className={PRE} style={PRE_STYLE}>
-        <code>Authorization: Bearer elu_YOUR_API_KEY</code>
-      </pre>
+      <p className={P}>
+        Account endpoints accept a scoped API key in the standard Bearer
+        header. Create a key under{' '}
+        <Link href="/profile/keys" className="text-[#b42318] underline">
+          Profile → API Keys
+        </Link>
+        . Never place API keys in URLs or browser-delivered JavaScript.
+      </p>
+      <CodeBlock label="Request header">
+        Authorization: Bearer elu_YOUR_API_KEY
+      </CodeBlock>
+      <div className="rounded-xl p-4 text-sm text-[#555] leading-relaxed" style={CALLOUT_STYLE}>
+        The guest endpoint does not accept an API key. It is protected by a
+        same-origin browser check, risk scoring, and a 24-hour D1 quota, so it
+        is not a replacement for the authenticated integration API.
+      </div>
+
+      <h2 id="guest-shortening" className={H2}>
+        <MethodBadge method="POST" />Guest shortening
+      </h2>
+      <Endpoint method="POST" path="/api/guest/urls" />
+      <p className={P}>
+        Creates one temporary short link from the public landing page. The
+        service fixes the expiry at 24 hours, generates the code, stores no
+        click analytics, and returns <code className={INLINE_CODE}>429</code>{' '}
+        while the derived guest identity is still inside its quota window.
+      </p>
+      <FieldTable rows={[
+        ['url', 'string', 'Yes', 'Absolute HTTP or HTTPS destination, maximum 2,048 characters. Private, loopback, unsafe, and denylisted hosts are rejected.'],
+      ]} />
+      <CodeBlock label="Same-origin browser request">{`fetch('/api/guest/urls', {
+  method: 'POST',
+  headers: { 'Content-Type': 'application/json' },
+  body: JSON.stringify({ url: 'https://example.com/article' })
+})`}</CodeBlock>
+      <CodeBlock label="201 Created">{`{
+  "short_url": "https://lixrl.com/gA1b2C3",
+  "short_code": "gA1b2C3",
+  "original_url": "https://example.com/article",
+  "expires_at": "2026-08-02T10:30:00.000Z",
+  "guest": true
+}`}</CodeBlock>
+      <h3 id="guest-limit-response" className={H3}>Guest quota response</h3>
+      <CodeBlock label="429 Too Many Requests">{`{
+  "error": "Your guest link has already been used. Sign in for persistent links.",
+  "account_required": true,
+  "available_at": "2026-08-02T10:30:00.000Z"
+}`}</CodeBlock>
+      <p className={P}>
+        The response includes <code className={INLINE_CODE}>Retry-After</code>{' '}
+        in seconds. Guest links cannot be listed, edited, recovered, or
+        converted into account links after creation.
+      </p>
 
       <h2 id="create-a-short-link" className={H2}>
-        <MethodBadge method="POST" />Create a short link
+        <MethodBadge method="POST" />Create an account link
       </h2>
-      <p className={P}>
-        <code className="font-mono text-white">POST /api/urls</code>
-      </p>
-      <pre className={PRE} style={PRE_STYLE}>
-        <code>{`curl -X POST https://lixrl.com/api/urls \\
+      <Endpoint method="POST" path="/api/urls" />
+      <FieldTable rows={[
+        ['url', 'string', 'Yes', 'Absolute HTTP or HTTPS destination. The same private-network and safe-content checks used by guest shortening apply.'],
+        ['title', 'string', 'No', 'Human-readable label between 1 and 255 characters.'],
+        ['custom_code', 'string', 'No', 'Pro or higher. A unique 3–32 character slug containing letters, digits, hyphens, or underscores.'],
+        ['expires_at', 'ISO 8601', 'No', 'Pro or higher. A future timestamp; null/omitted links do not expire.'],
+      ]} />
+      <CodeBlock label="cURL">{`curl -X POST https://lixrl.com/api/urls \\
   -H "Authorization: Bearer elu_YOUR_KEY" \\
   -H "Content-Type: application/json" \\
   -d '{
     "url": "https://example.com/long-url",
-    "title": "My Link",
-    "custom_code": "my-link"
-  }'`}</code>
-      </pre>
-      <pre className={PRE} style={PRE_STYLE}>
-        <code>{`{
-  "short_url": "https://lixrl.com/my-link",
-  "short_code": "my-link",
+    "title": "Launch announcement",
+    "custom_code": "launch",
+    "expires_at": "2026-12-31T23:59:59.000Z"
+  }'`}</CodeBlock>
+      <CodeBlock label="201 Created">{`{
+  "short_url": "https://lixrl.com/launch",
+  "short_code": "launch",
   "original_url": "https://example.com/long-url",
-  "title": "My Link",
-  "created_at": "2026-03-20T12:00:00Z"
-}`}</code>
-      </pre>
+  "title": "Launch announcement",
+  "created_at": "2026-08-01 10:30:00",
+  "expires_at": "2026-12-31T23:59:59.000Z"
+}`}</CodeBlock>
+      <p className={P}>
+        Free accounts can own up to 25 links. A duplicate custom code returns{' '}
+        <code className={INLINE_CODE}>409</code>; unavailable tier features and
+        exhausted account quotas return <code className={INLINE_CODE}>403</code>.
+      </p>
 
       <h2 id="list-your-links" className={H2}>
-        <MethodBadge method="GET" />List your links
+        <MethodBadge method="GET" />List account links
       </h2>
-      <p className={P}>
-        <code className="font-mono text-white">
-          GET /api/urls?limit=20&amp;offset=0&amp;search=example
-        </code>
-      </p>
-      <pre className={PRE} style={PRE_STYLE}>
-        <code>{`curl https://lixrl.com/api/urls?limit=20&offset=0 \\
-  -H "Authorization: Bearer elu_YOUR_KEY"`}</code>
-      </pre>
+      <Endpoint method="GET" path="/api/urls" />
+      <FieldTable rows={[
+        ['limit', 'integer', 'No', 'Page size from 1–100. Defaults to 50.'],
+        ['offset', 'integer', 'No', 'Number of matching records to skip. Defaults to 0; maximum 100,000.'],
+        ['search', 'string', 'No', 'Case-insensitive match against short code, destination, or title. Input is capped at 100 characters.'],
+      ]} />
+      <CodeBlock label="cURL">{`curl 'https://lixrl.com/api/urls?limit=20&offset=0&search=example' \\
+  -H "Authorization: Bearer elu_YOUR_KEY"`}</CodeBlock>
+      <CodeBlock label="200 OK">{`{
+  "urls": [
+    {
+      "id": 42,
+      "user_id": 7,
+      "short_code": "launch",
+      "original_url": "https://example.com/long-url",
+      "title": "Launch announcement",
+      "is_active": 1,
+      "clicks": 18,
+      "created_at": "2026-08-01 10:30:00",
+      "updated_at": "2026-08-01 10:30:00",
+      "expires_at": null
+    }
+  ],
+  "total": 1,
+  "limit": 20,
+  "offset": 0
+}`}</CodeBlock>
 
       <h2 id="get-a-link" className={H2}>
-        <MethodBadge method="GET" />Get a link
+        <MethodBadge method="GET" />Get an account link
       </h2>
+      <Endpoint method="GET" path="/api/urls/{code}" />
       <p className={P}>
-        <code className="font-mono text-white">
-          GET /api/urls/{'{code}'}
-        </code>
+        Returns the complete URL record shown in the list response. Ownership
+        is enforced: an unknown code or a code belonging to another account
+        returns <code className={INLINE_CODE}>404</code>.
       </p>
-      <pre className={PRE} style={PRE_STYLE}>
-        <code>{`curl https://lixrl.com/api/urls/my-link \\
-  -H "Authorization: Bearer elu_YOUR_KEY"`}</code>
-      </pre>
+      <CodeBlock label="cURL">{`curl https://lixrl.com/api/urls/launch \\
+  -H "Authorization: Bearer elu_YOUR_KEY"`}</CodeBlock>
 
       <h2 id="update-a-link" className={H2}>
-        <MethodBadge method="PATCH" />Update a link
+        <MethodBadge method="PATCH" />Update an account link
       </h2>
-      <p className={P}>
-        <code className="font-mono text-white">
-          PATCH /api/urls/{'{code}'}
-        </code>{' '}
-        — change destination URL, title, or active status.
-      </p>
-      <pre className={PRE} style={PRE_STYLE}>
-        <code>{`curl -X PATCH https://lixrl.com/api/urls/my-link \\
+      <Endpoint method="PATCH" path="/api/urls/{code}" />
+      <p className={P}>Send at least one mutable field. The short code itself cannot be changed.</p>
+      <FieldTable rows={[
+        ['url', 'string', 'No', 'New validated HTTP or HTTPS destination.'],
+        ['title', 'string | null', 'No', 'New 1–255 character title, or null to remove it.'],
+        ['is_active', 'boolean', 'No', 'False disables redirects without deleting the record or analytics.'],
+        ['expires_at', 'ISO 8601 | null', 'No', 'Future timestamp, or null to remove expiry.'],
+      ]} />
+      <CodeBlock label="cURL">{`curl -X PATCH https://lixrl.com/api/urls/launch \\
   -H "Authorization: Bearer elu_YOUR_KEY" \\
   -H "Content-Type: application/json" \\
-  -d '{"url": "https://new-destination.com", "is_active": true}'`}</code>
-      </pre>
+  -d '{"url":"https://example.com/new","title":null,"is_active":true}'`}</CodeBlock>
+      <CodeBlock label="200 OK">{`{
+  "success": true
+}`}</CodeBlock>
 
       <h2 id="delete-a-link" className={H2}>
-        <MethodBadge method="DELETE" />Delete a link
+        <MethodBadge method="DELETE" />Delete an account link
       </h2>
+      <Endpoint method="DELETE" path="/api/urls/{code}" />
       <p className={P}>
-        <code className="font-mono text-white">
-          DELETE /api/urls/{'{code}'}
-        </code>{' '}
-        — permanently removes the link and its analytics. This is
-        irreversible.
+        Permanently removes the link and its click records. This operation is
+        irreversible; use <code className={INLINE_CODE}>is_active: false</code>{' '}
+        when you may need to restore the redirect later.
       </p>
-      <pre className={PRE} style={PRE_STYLE}>
-        <code>{`curl -X DELETE https://lixrl.com/api/urls/my-link \\
-  -H "Authorization: Bearer elu_YOUR_KEY"`}</code>
-      </pre>
+      <CodeBlock label="cURL">{`curl -X DELETE https://lixrl.com/api/urls/launch \\
+  -H "Authorization: Bearer elu_YOUR_KEY"`}</CodeBlock>
+      <CodeBlock label="200 OK">{`{
+  "success": true
+}`}</CodeBlock>
+
+      <h2 id="status-codes" className={H2}>Status codes and retries</h2>
+      <div className="rounded-xl overflow-x-auto mb-6 border border-[#e2e2e2]">
+        <table className="w-full min-w-[560px] text-sm">
+          <thead className="bg-[#f7f7f6] text-[#444]">
+            <tr>
+              <th className="text-left px-4 py-2.5">Status</th>
+              <th className="text-left px-4 py-2.5">Meaning</th>
+              <th className="text-left px-4 py-2.5">Action</th>
+            </tr>
+          </thead>
+          <tbody className="text-[#555]">
+            {[
+              ['400', 'Malformed input or unsupported field value.', 'Correct the request before retrying.'],
+              ['401', 'Missing, invalid, expired, or revoked credentials.', 'Replace the API key.'],
+              ['403', 'Tier restriction, quota, risk rejection, or CSRF failure.', 'Read the error string; signing in or upgrading may be required.'],
+              ['404', 'The account does not own a matching short code.', 'Verify the code and credentials.'],
+              ['409', 'Requested custom code is already taken.', 'Choose another code or omit custom_code.'],
+              ['422', 'Safe Browsing rejected the destination.', 'Use a safe destination; do not retry unchanged.'],
+              ['429', 'Rate or guest quota exceeded.', 'Wait for Retry-After before retrying.'],
+              ['500/503', 'Transient service or configuration failure.', 'Retry with capped exponential backoff.'],
+            ].map(([status, meaning, action]) => (
+              <tr key={status} className="border-t border-[#ececec]">
+                <td className="px-4 py-3 font-mono font-semibold text-[#222]">{status}</td>
+                <td className="px-4 py-3">{meaning}</td>
+                <td className="px-4 py-3">{action}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <p className={P}>
+        See the dedicated{' '}
+        <Link href="/docs/errors" className="text-[#b42318] underline">
+          error reference
+        </Link>{' '}
+        for response conventions and retry guidance.
+      </p>
     </article>
   );
 }

--- a/app/docs/layout.tsx
+++ b/app/docs/layout.tsx
@@ -140,7 +140,11 @@ export default function DocsLayout({
     const list: HeadingItem[] = [];
     headingElements.forEach((el) => {
       const level = Number.parseInt(el.tagName.substring(1), 10);
-      const text = el.textContent || '';
+      const heading = el.cloneNode(true) as HTMLElement;
+      heading.querySelectorAll('[data-toc-ignore]').forEach((node) =>
+        node.remove(),
+      );
+      const text = (heading.textContent || '').trim();
       let id = el.id;
       if (!id) {
         id = text
@@ -199,7 +203,7 @@ export default function DocsLayout({
       {/* Search */}
       <div className="relative mb-5">
         <svg
-          className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-white/40"
+          className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-[#777]"
           viewBox="0 0 24 24"
           fill="none"
           stroke="currentColor"
@@ -215,7 +219,7 @@ export default function DocsLayout({
           placeholder="Search docs..."
           value={search}
           onChange={(e) => setSearch(e.target.value)}
-          className="w-full pl-9 pr-3 py-2 text-sm rounded-lg outline-none text-white placeholder-white/40 transition-colors"
+          className="w-full pl-9 pr-3 py-2 text-sm rounded-lg outline-none text-[#222] placeholder:text-[#999] transition-colors"
           style={{
             background: 'rgba(0,0,0,0.03)',
             border: '1px solid rgba(0,0,0,0.10)',
@@ -246,7 +250,7 @@ export default function DocsLayout({
                       : 'transparent',
                     color: active
                       ? ACCENT
-                      : 'rgba(255, 255, 255, 0.65)',
+                      : '#555555',
                     fontWeight: active ? 600 : 500,
                   }}
                   onMouseEnter={(e) => {
@@ -271,7 +275,7 @@ export default function DocsLayout({
             );
           })}
           {filteredNav.length === 0 && (
-            <li className="text-sm text-white/40 text-center py-4">
+            <li className="text-sm text-[#888] text-center py-4">
               No results found
             </li>
           )}
@@ -297,7 +301,7 @@ export default function DocsLayout({
               type="button"
               onClick={() => setMobileOpen(!mobileOpen)}
               aria-label="Open sidebar"
-              className="md:hidden w-10 h-10 inline-flex items-center justify-center rounded-lg text-white/85 hover:text-white"
+              className="md:hidden w-10 h-10 inline-flex items-center justify-center rounded-lg text-[#555] hover:text-[#111]"
               style={{ border: '1px solid rgba(0,0,0,0.10)' }}
             >
               <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
@@ -307,7 +311,7 @@ export default function DocsLayout({
               </svg>
             </button>
 
-            <Link href="/" className="flex items-center gap-2 no-underline text-white">
+            <Link href="/" className="flex items-center gap-2 no-underline text-[#111]">
               <img
                 src="/base_logo.png"
                 alt="ElixpoURL"
@@ -317,7 +321,7 @@ export default function DocsLayout({
               />
               <span className="font-bold text-[1rem] tracking-tight">
                 Elixpo<span style={{ color: ACCENT }}>URL</span>
-                <span className="text-white/55 font-medium"> &nbsp;Docs</span>
+                <span className="text-[#555] font-medium"> &nbsp;Docs</span>
               </span>
             </Link>
 
@@ -329,12 +333,12 @@ export default function DocsLayout({
               title={copied ? 'Copied!' : 'Copy this page as plain text to paste into an LLM'}
               className="hidden sm:inline-flex items-center gap-2 px-3 py-2 rounded-lg text-sm font-semibold transition-all"
               style={{
-                color: copied ? '#86efac' : 'rgba(0,0,0,0.75)',
+                color: copied ? '#15803d' : '#444444',
                 border: '1px solid rgba(0,0,0,0.12)',
               }}
               onMouseEnter={(e) => {
                 if (!copied) {
-                  e.currentTarget.style.color = '#fff';
+                  e.currentTarget.style.color = ACCENT;
                   e.currentTarget.style.background =
                     'rgba(229,57,53,0.08)';
                   e.currentTarget.style.borderColor =
@@ -368,7 +372,7 @@ export default function DocsLayout({
               className="hidden md:inline-flex items-center gap-2 px-3 py-2 rounded-lg text-sm font-semibold no-underline transition-colors"
               style={{ color: 'rgba(0,0,0,0.65)' }}
               onMouseEnter={(e) => {
-                e.currentTarget.style.color = '#fff';
+                e.currentTarget.style.color = '#111';
                 e.currentTarget.style.background = 'rgba(0,0,0,0.08)';
               }}
               onMouseLeave={(e) => {
@@ -390,7 +394,7 @@ export default function DocsLayout({
               target="_blank"
               rel="noopener noreferrer"
               aria-label="View source on GitHub"
-              className="w-10 h-10 inline-flex items-center justify-center rounded-lg text-white/85 hover:text-white transition-all"
+              className="w-10 h-10 inline-flex items-center justify-center rounded-lg text-[#555] hover:text-[#111] transition-all"
             >
               <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor">
                 <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
@@ -526,7 +530,7 @@ export default function DocsLayout({
                 style={{ height: 'calc(100vh - 60px)' }}
               >
                 <div className="p-6">
-                  <div className="text-[11px] font-bold tracking-[0.1em] uppercase text-white/45 mb-3">
+                  <div className="text-[11px] font-bold tracking-[0.1em] uppercase text-[#555] mb-3">
                     On this page
                   </div>
                   <ul className="list-none p-0 space-y-2">

--- a/app/docs/layout.tsx
+++ b/app/docs/layout.tsx
@@ -71,6 +71,22 @@ export default function DocsLayout({
         case 'pre':
           lines.push('', '```', (el.textContent || '').trim(), '```', '');
           return;
+        case 'table': {
+          const rows = Array.from(el.querySelectorAll('tr')).map((row) =>
+            Array.from(row.querySelectorAll('th, td')).map((cell) =>
+              (cell.textContent || '').trim().replace(/\|/g, '\\|'),
+            ),
+          );
+          if (rows.length > 0) {
+            lines.push('', `| ${rows[0].join(' | ')} |`);
+            lines.push(`| ${rows[0].map(() => '---').join(' | ')} |`);
+            rows.slice(1).forEach((row) =>
+              lines.push(`| ${row.join(' | ')} |`),
+            );
+            lines.push('');
+          }
+          return;
+        }
         case 'p':
           if (text) lines.push(text, '');
           return;

--- a/app/globals.css
+++ b/app/globals.css
@@ -40,6 +40,23 @@ body {
 .theme-light button.text-white { color: #ffffff; }
 .theme-light .placeholder-white\/40::placeholder { color: #999999; }
 
+/* Documentation code samples intentionally use a true dark surface. Several
+   older pages still carry inline dark-theme rgba values; !important keeps the
+   shared docs presentation consistent until those pages are consolidated. */
+#docs-content pre {
+  background: #171717 !important;
+  border-color: #2f2f2f !important;
+  color: #f5f5f4 !important;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
+}
+#docs-content pre code {
+  color: inherit;
+}
+#docs-content pre ::selection {
+  background: rgba(229, 57, 53, 0.45);
+  color: #ffffff;
+}
+
 body {
   font-family: var(--font-geist-sans), -apple-system, BlinkMacSystemFont,
     sans-serif;


### PR DESCRIPTION
## Changes Made
- `app/docs/api/page.tsx` — removed `'use client'` directive and added `Link` import, converting the docs page to a server component with proper TypeScript types (`Method`, `CSSProperties`, `ReactNode`).
- `app/docs/api/page.tsx` — replaced all hardcoded dark-theme colors (white text, `rgba(0,0,0,...)` backgrounds) with explicit light-theme hex values (`#111`, `#555`, `#171717` code blocks, etc.) so the page renders correctly regardless of site color theme.
- `app/docs/api/page.tsx` — added three reusable presentational components: `CodeBlock` (labeled code samples), `FieldTable` (structured field/type/required/description tables), and `Endpoint` (method badge + path wrapper) to replace inline `<pre>` and `<p>` blocks.
- `app/docs/api/page.tsx` — added `H3`, `INLINE_CODE`, and `CALLOUT_STYLE` style constants, plus `scroll-mt-24` on headings for anchor scroll offset.
- `app/docs/api/page.tsx` — expanded API documentation content: added guest shortening endpoint with quota/429 response, field tables for every endpoint, full response-body examples, a status-codes-and-retries table, tier/quota notes, and base-URL/auth info cards.
- `app/docs/api/page.tsx` — added `data-toc-ignore` and `aria-hidden` to `MethodBadge` so method tags don't pollute table-of-contents or screen-reader output.

## Checklist
- [ ] `./biome.sh ci` clean
- [ ] Tested locally: <how>