### PR TITLE
[FEAT]:- attachment of the cross platform sharing

### DIFF
--- a/app/api/integrations/blogs/route.ts
+++ b/app/api/integrations/blogs/route.ts
@@ -1,0 +1,159 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { auditLog } from '@/lib/auth';
+import { createUrlForUser } from '@/lib/create-url';
+import { getDB, getEnv } from '@/lib/db';
+import { rateLimitSubject } from '@/lib/ratelimit';
+import { TIER_LIMITS, type User } from '@/lib/types';
+
+export const runtime = 'edge';
+
+const SERVICE = 'blogs';
+
+interface DelegatedIdentity {
+  id?: unknown;
+  email?: unknown;
+  display_name?: unknown;
+  avatar_url?: unknown;
+}
+
+async function serviceAuthorized(request: NextRequest): Promise<boolean> {
+  const configured = getEnv().BLOGS_INTEGRATION_TOKEN;
+  const provided = request.headers.get('authorization');
+  if (!configured || !provided) return false;
+  const encoder = new TextEncoder();
+  const [expected, actual] = await Promise.all([
+    crypto.subtle.digest('SHA-256', encoder.encode(`Bearer ${configured}`)),
+    crypto.subtle.digest('SHA-256', encoder.encode(provided)),
+  ]);
+  const left = new Uint8Array(expected);
+  const right = new Uint8Array(actual);
+  let mismatch = left.length ^ right.length;
+  for (let index = 0; index < left.length; index++) mismatch |= left[index] ^ (right[index] || 0);
+  return mismatch === 0;
+}
+
+function parseIdentity(value: unknown): { id: string; email: string; displayName: string; avatar: string | null } | null {
+  if (!value || typeof value !== 'object') return null;
+  const identity = value as DelegatedIdentity;
+  const id = typeof identity.id === 'string' ? identity.id.trim() : '';
+  const email = typeof identity.email === 'string' ? identity.email.trim().toLowerCase() : '';
+  const displayName = typeof identity.display_name === 'string' ? identity.display_name.trim() : '';
+  const avatar = typeof identity.avatar_url === 'string' && identity.avatar_url.trim() ? identity.avatar_url.trim() : null;
+  if (!id || !email || !displayName || id.length > 128 || email.length > 320 || displayName.length > 100) return null;
+  return { id, email, displayName, avatar };
+}
+
+async function findUser(elixpoId: string): Promise<User | null> {
+  const user = await getDB().prepare('SELECT * FROM users WHERE elixpo_id = ? AND is_active = 1')
+    .bind(elixpoId).first<User>();
+  if (user?.tier !== 'free' && user?.tier_expires_at && Date.parse(user.tier_expires_at) < Date.now()) {
+    return { ...user, tier: 'free' };
+  }
+  return user;
+}
+
+async function upsertDelegatedUser(identity: ReturnType<typeof parseIdentity>): Promise<User | null> {
+  if (!identity) return null;
+  const db = getDB();
+  const existing = await findUser(identity.id);
+  if (existing) {
+    const emailOwner = await db.prepare('SELECT id FROM users WHERE email = ? AND id != ?')
+      .bind(identity.email, existing.id).first();
+    if (emailOwner) return null;
+    await db.prepare(
+      `UPDATE users SET email = ?, display_name = ?, avatar_url = ?, updated_at = datetime('now') WHERE id = ?`,
+    ).bind(identity.email, identity.displayName, identity.avatar, existing.id).run();
+    return { ...existing, email: identity.email, display_name: identity.displayName, avatar_url: identity.avatar };
+  }
+
+  const emailOwner = await db.prepare('SELECT id FROM users WHERE email = ?').bind(identity.email).first();
+  if (emailOwner) return null;
+  return db.prepare(
+    `INSERT INTO users (elixpo_id, email, display_name, avatar_url)
+     VALUES (?, ?, ?, ?) RETURNING *`,
+  ).bind(identity.id, identity.email, identity.displayName, identity.avatar).first<User>();
+}
+
+async function isConnected(userId: number): Promise<boolean> {
+  const row = await getDB().prepare(
+    'SELECT user_id FROM service_bindings WHERE user_id = ? AND service = ? AND revoked_at IS NULL',
+  ).bind(userId, SERVICE).first();
+  return Boolean(row);
+}
+
+async function accountStatus(user: User) {
+  const count = await getDB().prepare('SELECT COUNT(*) AS count FROM urls WHERE user_id = ?')
+    .bind(user.id).first<{ count: number }>();
+  return {
+    connected: true,
+    account: {
+      display_name: user.display_name,
+      avatar_url: user.avatar_url,
+      tier: user.tier,
+      limits: TIER_LIMITS[user.tier],
+      usage: { urls: count?.count || 0 },
+    },
+  };
+}
+
+export async function POST(request: NextRequest) {
+  if (!(await serviceAuthorized(request))) {
+    return NextResponse.json({ error: 'Unauthorized integration' }, { status: 401 });
+  }
+
+  let body: any;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  const action = body?.action;
+  const identity = parseIdentity(body?.user);
+  if (!identity) return NextResponse.json({ error: 'Valid user identity is required' }, { status: 400 });
+
+  if (action === 'status') {
+    const user = await findUser(identity.id);
+    if (!user || !(await isConnected(user.id))) return NextResponse.json({ connected: false });
+    return NextResponse.json(await accountStatus(user));
+  }
+
+  if (action === 'connect') {
+    const user = await upsertDelegatedUser(identity);
+    if (!user) return NextResponse.json({ error: 'This email is already attached to another LixRL account' }, { status: 409 });
+    await getDB().prepare(
+      `INSERT INTO service_bindings (user_id, service) VALUES (?, ?)
+       ON CONFLICT(user_id, service) DO UPDATE SET revoked_at = NULL, connected_at = datetime('now')`,
+    ).bind(user.id, SERVICE).run();
+    auditLog(user.id, 'integration.connect', 'service', SERVICE).catch(() => {});
+    return NextResponse.json(await accountStatus(user));
+  }
+
+  const user = await findUser(identity.id);
+  if (!user || !(await isConnected(user.id))) {
+    return NextResponse.json({ error: 'Connect LixRL in Blogs settings first', connected: false }, { status: 409 });
+  }
+
+  if (action === 'disconnect') {
+    await getDB().prepare(
+      `UPDATE service_bindings SET revoked_at = datetime('now') WHERE user_id = ? AND service = ?`,
+    ).bind(user.id, SERVICE).run();
+    auditLog(user.id, 'integration.disconnect', 'service', SERVICE).catch(() => {});
+    return NextResponse.json({ connected: false });
+  }
+
+  if (action === 'shorten') {
+    const limit = TIER_LIMITS[user.tier].rateLimitPerMin;
+    const limited = await rateLimitSubject('integration:blogs:shorten', String(user.id), limit, 60);
+    if (limited) return limited;
+    const response = await createUrlForUser(user, { url: body.url, title: body.title });
+    if (response.ok) {
+      getDB().prepare(
+        `UPDATE service_bindings SET last_used_at = datetime('now') WHERE user_id = ? AND service = ?`,
+      ).bind(user.id, SERVICE).run().catch(() => {});
+    }
+    return response;
+  }
+
+  return NextResponse.json({ error: 'Unsupported action' }, { status: 400 });
+}

--- a/app/api/urls/route.ts
+++ b/app/api/urls/route.ts
@@ -1,19 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { resolveUser, auditLog } from '@/lib/auth';
-import { getDB, getKV, getEnv } from '@/lib/db';
-import { generateShortCode } from '@/lib/utils';
-import { TIER_LIMITS, type UrlRecord } from '@/lib/types';
-import {
-  badRequest,
-  clampInt,
-  validateFutureDate,
-  validateLength,
-  validateSlug,
-  validateUrl,
-} from '@/lib/validate';
+import { resolveUser } from '@/lib/auth';
+import { getDB } from '@/lib/db';
+import { type UrlRecord } from '@/lib/types';
+import { clampInt } from '@/lib/validate';
 import { requireSameOrigin } from '@/lib/csrf';
 import { rateLimit } from '@/lib/ratelimit';
-import { checkSafeBrowsing, threatMessage } from '@/lib/safebrowsing';
+import { createUrlForUser } from '@/lib/create-url';
 
 export const runtime = 'edge';
 
@@ -29,112 +21,8 @@ export async function POST(request: NextRequest) {
   const user = await resolveUser(request);
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
-  const body: any = await request.json();
-  const { url, custom_code, title, expires_at } = body;
-  const limits = TIER_LIMITS[user.tier];
-  const db = getDB();
-  const kv = getKV();
-  const env = getEnv();
-
-  // Validate URL — static checks first (free, instant)
-  if (!url || typeof url !== 'string') return badRequest('url is required');
-  const urlErr = validateUrl(url);
-  if (urlErr) return badRequest(urlErr);
-
-  // Safe Browsing — paid signal, only runs if SAFE_BROWSING_API_KEY is set.
-  // Treated as a non-blocker if the API is down (fail-open by design — see
-  // lib/safebrowsing.ts). Real positives DO block.
-  const threat = await checkSafeBrowsing(url, env.SAFE_BROWSING_API_KEY);
-  if (threat) {
-    return NextResponse.json(
-      { error: threatMessage(threat) },
-      { status: 422 },
-    );
-  }
-
-  // Validate title length
-  if (title) {
-    if (typeof title !== 'string') return badRequest('title must be a string');
-    const titleErr = validateLength(title, 'Title', 1, 255);
-    if (titleErr) return badRequest(titleErr);
-  }
-
-  // Validate expires_at
-  if (expires_at) {
-    if (!limits.expiringLinks) {
-      return NextResponse.json({ error: 'Expiring links require Pro tier or above' }, { status: 403 });
-    }
-    const dateErr = validateFutureDate(expires_at);
-    if (dateErr) return badRequest(dateErr);
-  }
-
-  // Check URL limit
-  if (limits.maxUrls !== -1) {
-    const count = await db.prepare('SELECT COUNT(*) as count FROM urls WHERE user_id = ?')
-      .bind(user.id).first<{ count: number }>();
-    if ((count?.count || 0) >= limits.maxUrls) {
-      return NextResponse.json({ error: `URL limit reached (${limits.maxUrls} for ${user.tier} tier)` }, { status: 403 });
-    }
-  }
-
-  // Validate custom code (reserved/NSFW check + DB uniqueness)
-  if (custom_code) {
-    if (!limits.customCodes) {
-      return NextResponse.json({ error: 'Custom short codes require Pro tier or above' }, { status: 403 });
-    }
-    if (typeof custom_code !== 'string') return badRequest('custom_code must be a string');
-
-    const slugErr = validateSlug(custom_code);
-    if (slugErr) return badRequest(slugErr);
-
-    const existing = await db
-      .prepare(
-        `SELECT short_code FROM urls WHERE short_code = ?
-         UNION ALL
-         SELECT short_code FROM guest_links WHERE short_code = ?
-         LIMIT 1`,
-      )
-      .bind(custom_code, custom_code)
-      .first();
-    if (existing) return NextResponse.json({ error: 'Short code already taken' }, { status: 409 });
-  }
-
-  // For auto-generated codes, retry up to 5 times if we hit a
-  // reserved/NSFW collision (extremely rare with a 6-char alphanum space).
-  let shortCode = custom_code;
-  if (!shortCode) {
-    for (let attempt = 0; attempt < 5; attempt++) {
-      const candidate = generateShortCode();
-      if (!validateSlug(candidate)) {
-        shortCode = candidate;
-        break;
-      }
-    }
-    if (!shortCode) {
-      return NextResponse.json({ error: 'Could not generate a safe slug, please retry' }, { status: 500 });
-    }
-  }
-
-  const result = await db
-    .prepare('INSERT INTO urls (user_id, short_code, original_url, title, expires_at) VALUES (?, ?, ?, ?, ?) RETURNING *')
-    .bind(user.id, shortCode, url, title || null, expires_at ? new Date(expires_at).toISOString() : null)
-    .first<UrlRecord>();
-
-  // Cache in KV
-  const kvValue = JSON.stringify({ url, id: result!.id });
-  const ttl = expires_at ? Math.max(Math.floor((new Date(expires_at).getTime() - Date.now()) / 1000), 60) : undefined;
-  kv.put(`url:${shortCode}`, kvValue, { expirationTtl: ttl }).catch(() => {});
-
-  auditLog(user.id, 'url.create', 'url', shortCode, url).catch(() => {});
-
-  return NextResponse.json({
-    short_url: `${env.BASE_URL}/${shortCode}`,
-    short_code: shortCode,
-    original_url: url,
-    title: result?.title,
-    created_at: result?.created_at,
-    expires_at: result?.expires_at,
-  }, { status: 201 });
+  const body = await request.json() as import('@/lib/create-url').CreateUrlInput;
+  return createUrlForUser(user, body);
 }
 
 export async function GET(request: NextRequest) {

--- a/env.d.ts
+++ b/env.d.ts
@@ -8,6 +8,7 @@ interface CloudflareEnv {
   SAFE_BROWSING_API_KEY: string;
   GUEST_FINGERPRINT_SECRET: string;
   ELIXPO_WEBHOOK_SECRET: string;
+  BLOGS_INTEGRATION_TOKEN: string;
   // Elixpo Pay — subscriptions / autopay.
   ELIXPO_PAY_BASE_URL: string;
   ELIXPO_PAY_APP_ID: string;

--- a/lib/create-url.ts
+++ b/lib/create-url.ts
@@ -1,0 +1,118 @@
+import { NextResponse } from 'next/server';
+import { auditLog } from '@/lib/auth';
+import { getDB, getEnv, getKV } from '@/lib/db';
+import { checkSafeBrowsing, threatMessage } from '@/lib/safebrowsing';
+import { TIER_LIMITS, type UrlRecord, type User } from '@/lib/types';
+import { generateShortCode } from '@/lib/utils';
+import {
+  badRequest,
+  validateFutureDate,
+  validateLength,
+  validateSlug,
+  validateUrl,
+} from '@/lib/validate';
+
+export interface CreateUrlInput {
+  url?: unknown;
+  custom_code?: unknown;
+  title?: unknown;
+  expires_at?: unknown;
+}
+
+/** Shared URL creation path for the LixRL UI/API and trusted integrations. */
+export async function createUrlForUser(user: User, input: CreateUrlInput) {
+  const { url, custom_code, title, expires_at } = input;
+  const limits = TIER_LIMITS[user.tier];
+  const db = getDB();
+  const kv = getKV();
+  const env = getEnv();
+
+  if (!url || typeof url !== 'string') return badRequest('url is required');
+  const urlErr = validateUrl(url);
+  if (urlErr) return badRequest(urlErr);
+
+  const threat = await checkSafeBrowsing(url, env.SAFE_BROWSING_API_KEY);
+  if (threat) {
+    return NextResponse.json({ error: threatMessage(threat) }, { status: 422 });
+  }
+
+  if (title) {
+    if (typeof title !== 'string') return badRequest('title must be a string');
+    const titleErr = validateLength(title, 'Title', 1, 255);
+    if (titleErr) return badRequest(titleErr);
+  }
+
+  if (expires_at) {
+    if (!limits.expiringLinks) {
+      return NextResponse.json({ error: 'Expiring links require Pro tier or above' }, { status: 403 });
+    }
+    if (typeof expires_at !== 'string') return badRequest('expires_at must be a string');
+    const dateErr = validateFutureDate(expires_at);
+    if (dateErr) return badRequest(dateErr);
+  }
+
+  if (limits.maxUrls !== -1) {
+    const count = await db.prepare('SELECT COUNT(*) as count FROM urls WHERE user_id = ?')
+      .bind(user.id).first<{ count: number }>();
+    if ((count?.count || 0) >= limits.maxUrls) {
+      return NextResponse.json({ error: `URL limit reached (${limits.maxUrls} for ${user.tier} tier)` }, { status: 403 });
+    }
+  }
+
+  if (custom_code) {
+    if (!limits.customCodes) {
+      return NextResponse.json({ error: 'Custom short codes require Pro tier or above' }, { status: 403 });
+    }
+    if (typeof custom_code !== 'string') return badRequest('custom_code must be a string');
+    const slugErr = validateSlug(custom_code);
+    if (slugErr) return badRequest(slugErr);
+
+    const existing = await db.prepare(
+      `SELECT short_code FROM urls WHERE short_code = ?
+       UNION ALL
+       SELECT short_code FROM guest_links WHERE short_code = ?
+       LIMIT 1`,
+    ).bind(custom_code, custom_code).first();
+    if (existing) return NextResponse.json({ error: 'Short code already taken' }, { status: 409 });
+  }
+
+  let shortCode = typeof custom_code === 'string' ? custom_code : '';
+  if (!shortCode) {
+    for (let attempt = 0; attempt < 5; attempt++) {
+      const candidate = generateShortCode();
+      if (!validateSlug(candidate)) {
+        const collision = await db.prepare(
+          `SELECT short_code FROM urls WHERE short_code = ?
+           UNION ALL
+           SELECT short_code FROM guest_links WHERE short_code = ?
+           LIMIT 1`,
+        ).bind(candidate, candidate).first();
+        if (!collision) {
+          shortCode = candidate;
+          break;
+        }
+      }
+    }
+    if (!shortCode) {
+      return NextResponse.json({ error: 'Could not generate a safe slug, please retry' }, { status: 500 });
+    }
+  }
+
+  const expiry = typeof expires_at === 'string' ? new Date(expires_at).toISOString() : null;
+  const result = await db.prepare(
+    'INSERT INTO urls (user_id, short_code, original_url, title, expires_at) VALUES (?, ?, ?, ?, ?) RETURNING *',
+  ).bind(user.id, shortCode, url, typeof title === 'string' ? title : null, expiry).first<UrlRecord>();
+
+  const ttl = expiry ? Math.max(Math.floor((new Date(expiry).getTime() - Date.now()) / 1000), 60) : undefined;
+  kv.put(`url:${shortCode}`, JSON.stringify({ url, id: result!.id }), { expirationTtl: ttl }).catch(() => {});
+  auditLog(user.id, 'url.create', 'url', shortCode, url).catch(() => {});
+
+  return NextResponse.json({
+    short_url: `${env.BASE_URL}/${shortCode}`,
+    short_code: shortCode,
+    original_url: url,
+    title: result?.title,
+    created_at: result?.created_at,
+    expires_at: result?.expires_at,
+  }, { status: 201 });
+}

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -27,6 +27,9 @@ export function getEnv() {
     // verify the HMAC on /api/webhooks/elixpo. Must match the secret
     // configured on the accounts.elixpo side.
     ELIXPO_WEBHOOK_SECRET: (ctx as any).ELIXPO_WEBHOOK_SECRET || process.env.ELIXPO_WEBHOOK_SECRET || '',
+    // Server-to-server credential used by Blogs for delegated link creation.
+    // This is never a browser-facing or per-user API key.
+    BLOGS_INTEGRATION_TOKEN: (ctx as any).BLOGS_INTEGRATION_TOKEN || process.env.BLOGS_INTEGRATION_TOKEN || '',
     // Elixpo Pay — subscriptions / autopay. API key creates checkout
     // sessions + authorizes catalog sync (POST /v1/sync); webhook secret
     // verifies the inbound entitlement.updated signature (t=,v1= scheme).

--- a/lib/ratelimit.ts
+++ b/lib/ratelimit.ts
@@ -36,3 +36,34 @@ export async function rateLimit(
 
   return null; // Allowed
 }
+
+/** Rate-limit an authenticated subject without coupling the quota to its IP. */
+export async function rateLimitSubject(
+  key: string,
+  subject: string,
+  maxRequests: number,
+  windowSeconds: number,
+): Promise<NextResponse | null> {
+  if (maxRequests === -1) return null;
+
+  const kv = getKV();
+  const rateLimitKey = `rl:${key}:${subject}`;
+  const current = parseInt((await kv.get(rateLimitKey)) || '0', 10);
+
+  if (current >= maxRequests) {
+    return NextResponse.json(
+      { error: 'Too many requests' },
+      {
+        status: 429,
+        headers: {
+          'Retry-After': String(windowSeconds),
+          'X-RateLimit-Limit': String(maxRequests),
+          'X-RateLimit-Remaining': '0',
+        },
+      },
+    );
+  }
+
+  kv.put(rateLimitKey, String(current + 1), { expirationTtl: windowSeconds }).catch(() => {});
+  return null;
+}

--- a/workers/migrations/0005_service_bindings.sql
+++ b/workers/migrations/0005_service_bindings.sql
@@ -1,0 +1,15 @@
+-- Explicit consent for first-party Elixpo services acting on a LixRL account.
+-- Revoking a binding stops future delegated actions but leaves existing links
+-- intact under the user's LixRL account.
+CREATE TABLE IF NOT EXISTS service_bindings (
+  user_id INTEGER NOT NULL,
+  service TEXT NOT NULL,
+  connected_at TEXT NOT NULL DEFAULT (datetime('now')),
+  last_used_at TEXT,
+  revoked_at TEXT,
+  PRIMARY KEY (user_id, service),
+  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_service_bindings_service_active
+  ON service_bindings(service, revoked_at);


### PR DESCRIPTION
## Changes Made
- Added `app/api/integrations/blogs/route.ts` — new edge API route for the Blogs platform integration. Supports `status`, `connect`, `disconnect`, and `shorten` actions, authorized via a shared bearer token compared with constant-time SHA-256 digests. Delegates user identity from Blogs and upserts into `users`, tracks bindings in `service_bindings`, and applies per-tier rate limits on the shorten action.
- Added `lib/create-url.ts` — extracted the URL creation logic (validation, Safe Browsing check, slug generation, DB insert, KV cache, audit log) into a shared `createUrlForUser` helper so both the main URLs API and trusted integrations use the same code path. Slug generation now also checks for DB collisions, not just reserved/NSFW lists.
- Refactored `app/api/urls/route.ts` — POST handler now delegates to `createUrlForUser` instead of inlining all validation and insert logic. Removed unused imports.
- Updated `env.d.ts` and `lib/db.ts` — added `BLOGS_INTEGRATION_TOKEN` to the `CloudflareEnv` interface and `getEnv()` so the integration route can read the server-to-server credential.

## Checklist
- [x] `export const runtime = 'edge'` on any new API route
- [x] No Node built-ins imported (crypto, fs, path, stream, Buffer) — note: new route uses `crypto.subtle` (Web Crypto, not Node `crypto`)
- [x] No new DB columns/tables — uses existing `service_bindings` table
- [ ] `./biome.sh ci` clean
- [ ] Tested locally: <how>

Fixes #8