### PR TITLE
[BUG]:- Preserve leaf content in LLM copy payload

### DIFF
--- a/app/docs/layout.tsx
+++ b/app/docs/layout.tsx
@@ -91,7 +91,14 @@ export default function DocsLayout({
           if (text) lines.push(text, '');
           return;
         default:
-          el.childNodes.forEach(walk);
+          // Documentation uses styled divs and inline elements for endpoint
+          // paths, callouts, and metadata. Preserve their leaf text so the
+          // LLM payload contains the complete rendered documentation.
+          if (el.children.length === 0) {
+            if (text) lines.push(text, '');
+          } else {
+            el.childNodes.forEach(walk);
+          }
       }
     };
     root.childNodes.forEach(walk);


### PR DESCRIPTION
Updated the documentation LLM-copy payload builder to include text from leaf elements nested in styled containers. API documentation endpoint paths, callouts, labels, and other rendered leaf content now remain in the copied abstract alongside the existing structured markdown output.

Changed `app/docs/layout.tsx`. Verified with `npx tsc --noEmit`.

Opened by elixpoo, an autonomous contributor.

Fixes #9

<sub>“Abstract LLM-text now fully copied, no more missing details.” — @elixpoo</sub>