### PR TITLE
[ELIXPO] scale QR SVG and canvas to fill display container

### DIFF
--- a/app/dashboard/urls/[code]/StyledQr.tsx
+++ b/app/dashboard/urls/[code]/StyledQr.tsx
@@ -87,7 +87,7 @@ const StyledQr = forwardRef<StyledQrHandle, Props>(function StyledQr(
   return (
     <div
       ref={containerRef}
-      className={className}
+      className={`[&>svg]:w-full [&>svg]:h-full [&>svg]:block [&>canvas]:w-full [&>canvas]:h-full [&>canvas]:block ${className || ''}`}
       style={{ width: display, height: display, ...style }}
     />
   );


### PR DESCRIPTION
## What this does
Scales the SVG and canvas elements of the generated QR code to fill the display container size (220px) rather than overflowing at their full backbuffer size (1024px) during initialization and update.

## Why
Fixes an overflow issue in the link settings page where the QR code overflows the card bounds and page layout.

## Changes
- \pp/dashboard/urls/[code]/StyledQr.tsx\: Styled container div using Tailwind class selectors to constraint nested svg/canvas elements to 100% width and height.

## Verification
- \
pm run build\ clean
- Verified locally that the CSS constraints prevent overflow during QR styling updates.

---
Fixes #13