### PR TITLE
[ELIXPO] prevent showing Upgrade to Pro to users on higher tiers

### DIFF
--- a/app/pricing/page.tsx
+++ b/app/pricing/page.tsx
@@ -274,6 +274,7 @@ export default function PricingPage() {
                   submitting={submitting}
                   popular={isPopular}
                   onSelect={select}
+                  currentTier={me.currentTier}
                 />
 
                 <ul className="space-y-2 list-none p-0 mt-6">
@@ -404,6 +405,7 @@ function CtaButton({
   submitting,
   popular,
   onSelect,
+  currentTier,
 }: {
   tier: SellableTier;
   loaded: boolean;
@@ -412,6 +414,7 @@ function CtaButton({
   submitting: SellableTier | null;
   popular: boolean;
   onSelect: (t: SellableTier) => void;
+  currentTier: string | null;
 }) {
   const thisSubmitting = submitting === tier;
   // Disabled while: page not yet loaded (idempotency guard — no clicks
@@ -420,11 +423,18 @@ function CtaButton({
   const isCurrentPlanCta = isCurrent || (tier === 'free' && loggedIn);
   const disabled = !loaded || submitting !== null || isCurrentPlanCta;
 
+  const currentTierIndex = currentTier === 'enterprise' ? 3 : SELLABLE_TIER_ORDER.indexOf(currentTier as SellableTier);
+  const cardTierIndex = SELLABLE_TIER_ORDER.indexOf(tier);
+  const isDowngrade = loggedIn && currentTierIndex > cardTierIndex;
+
   let label: string;
   if (!loaded) label = 'Loading…';
   else if (thisSubmitting) label = 'Starting checkout…';
   else if (isCurrent) label = 'Current plan';
-  else if (tier === 'free') label = loggedIn ? 'Included' : 'Start for free';
+  else if (isDowngrade) {
+    const tierNames: Record<SellableTier, string> = { free: 'Free', pro: 'Pro', business: 'Business' };
+    label = `Downgrade to ${tierNames[tier]}`;
+  } else if (tier === 'free') label = loggedIn ? 'Included' : 'Start for free';
   else if (!loggedIn) label = `Sign in to get ${tier === 'pro' ? 'Pro' : 'Business'}`;
   else label = `Upgrade to ${tier === 'pro' ? 'Pro' : 'Business'}`;
 


### PR DESCRIPTION
## What this does
Compares the user's current tier to the price card's tier on the pricing page. If the user holds a higher tier, the CTA button is labeled "Downgrade to..." instead of "Upgrade to...".

## Why
Fixes a bug where users on the Business plan see "Upgrade to Pro" nudge links, which is misleading.

## Changes
- `app/pricing/page.tsx`: Passed `currentTier` to `CtaButton` and added index-based comparison to show a Downgrade CTA when the card represents a tier lower than the user's current plan.

## Verification
- `npm run build` clean
- Verified locally that button labels dynamically change to "Downgrade to Pro" or "Downgrade to Free" for users logged in with a tier > card tier.

---
Fixes #1
