### PR TITLE
[ELIXPO] Add paid branded subdomain routing

### DIFF
--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -33,3 +33,6 @@ jobs:
 
       - name: Build Cloudflare Pages output
         run: npm run pages:build
+
+      - name: Build wildcard subdomain Worker
+        run: npx wrangler deploy --config wrangler.subdomains.toml --dry-run

--- a/app/api/subdomains/[id]/links/[code]/route.ts
+++ b/app/api/subdomains/[id]/links/[code]/route.ts
@@ -1,0 +1,32 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { auditLog, resolveUser } from '@/lib/auth';
+import { requireSameOrigin } from '@/lib/csrf';
+import { getDB } from '@/lib/db';
+import { bumpSubdomainRevision } from '@/lib/subdomain-control';
+
+export const runtime = 'edge';
+
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string; code: string }> },
+) {
+  const csrfError = requireSameOrigin(request);
+  if (csrfError) return csrfError;
+  const user = await resolveUser(request, 'write');
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  const resolved = await params;
+  const id = Number(resolved.id);
+  const result = await getDB()
+    .prepare(
+      `DELETE FROM subdomain_links
+       WHERE subdomain_id = ? AND short_code = ?
+         AND subdomain_id IN (SELECT id FROM subdomains WHERE user_id = ?)
+       RETURNING id`,
+    )
+    .bind(id, resolved.code.toLowerCase(), user.id)
+    .first<{ id: number }>();
+  if (!result) return NextResponse.json({ error: 'Mapped link not found' }, { status: 404 });
+  await bumpSubdomainRevision(getDB(), id);
+  auditLog(user.id, 'subdomain.unlink', 'subdomain', String(id), resolved.code).catch(() => {});
+  return NextResponse.json({ success: true });
+}

--- a/app/api/subdomains/[id]/links/route.ts
+++ b/app/api/subdomains/[id]/links/route.ts
@@ -1,0 +1,79 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { auditLog, resolveUser } from '@/lib/auth';
+import { requireSameOrigin } from '@/lib/csrf';
+import { getDB } from '@/lib/db';
+import { bumpSubdomainRevision } from '@/lib/subdomain-control';
+import { validateSlug } from '@/lib/validate';
+
+export const runtime = 'edge';
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const user = await resolveUser(request);
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  const id = Number((await params).id);
+  const { results } = await getDB()
+    .prepare(
+      `SELECT dl.id, dl.short_code, dl.url_id, dl.created_at,
+              u.short_code AS fallback_code, u.original_url, u.title
+       FROM subdomain_links dl
+       JOIN subdomains s ON s.id = dl.subdomain_id
+       JOIN urls u ON u.id = dl.url_id
+       WHERE dl.subdomain_id = ? AND s.user_id = ?
+       ORDER BY dl.created_at DESC`,
+    )
+    .bind(id, user.id)
+    .all();
+  return NextResponse.json({ links: results || [] });
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const csrfError = requireSameOrigin(request);
+  if (csrfError) return csrfError;
+  const user = await resolveUser(request, 'write');
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  const id = Number((await params).id);
+  if (!Number.isSafeInteger(id) || id < 1) return NextResponse.json({ error: 'Invalid subdomain id' }, { status: 400 });
+  const body = await request.json().catch(() => null) as { url_code?: unknown; short_code?: unknown } | null;
+  if (!body || typeof body.url_code !== 'string') {
+    return NextResponse.json({ error: 'url_code is required' }, { status: 400 });
+  }
+  const brandedCode = typeof body.short_code === 'string' && body.short_code
+    ? body.short_code.toLowerCase()
+    : body.url_code.toLowerCase();
+  const slugError = validateSlug(brandedCode);
+  if (slugError) return NextResponse.json({ error: slugError }, { status: 400 });
+
+  const db = getDB();
+  const domain = await db
+    .prepare("SELECT hostname FROM subdomains WHERE id = ? AND user_id = ? AND status = 'active'")
+    .bind(id, user.id)
+    .first<{ hostname: string }>();
+  if (!domain) return NextResponse.json({ error: 'Active subdomain not found' }, { status: 404 });
+  const url = await db
+    .prepare('SELECT id, short_code FROM urls WHERE user_id = ? AND short_code = ?')
+    .bind(user.id, body.url_code)
+    .first<{ id: number; short_code: string }>();
+  if (!url) return NextResponse.json({ error: 'Link not found' }, { status: 404 });
+
+  try {
+    await db
+      .prepare('INSERT INTO subdomain_links (subdomain_id, url_id, short_code) VALUES (?, ?, ?)')
+      .bind(id, url.id, brandedCode)
+      .run();
+    await bumpSubdomainRevision(db, id);
+  } catch {
+    return NextResponse.json({ error: 'This code or link is already assigned on the subdomain' }, { status: 409 });
+  }
+  auditLog(user.id, 'subdomain.link', 'subdomain', String(id), `${domain.hostname}/${brandedCode}`).catch(() => {});
+  return NextResponse.json({
+    short_url: `https://${domain.hostname}/${brandedCode}`,
+    fallback_url: `https://lixrl.com/${url.short_code}`,
+    short_code: brandedCode,
+  }, { status: 201 });
+}

--- a/app/api/subdomains/[id]/route.ts
+++ b/app/api/subdomains/[id]/route.ts
@@ -1,0 +1,68 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { auditLog, resolveUser } from '@/lib/auth';
+import { requireSameOrigin } from '@/lib/csrf';
+import { getDB } from '@/lib/db';
+import { publicSubdomain } from '@/lib/subdomain-control';
+import type { SubdomainRecord } from '@/lib/types';
+
+export const runtime = 'edge';
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const csrfError = requireSameOrigin(request);
+  if (csrfError) return csrfError;
+  const user = await resolveUser(request, 'write');
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  const id = Number((await params).id);
+  if (!Number.isSafeInteger(id) || id < 1) return NextResponse.json({ error: 'Invalid subdomain id' }, { status: 400 });
+
+  const body = await request.json().catch(() => null) as { is_default?: unknown } | null;
+  if (!body || body.is_default !== true) {
+    return NextResponse.json({ error: 'is_default must be true' }, { status: 400 });
+  }
+
+  const db = getDB();
+  const owned = await db
+    .prepare("SELECT * FROM subdomains WHERE id = ? AND user_id = ? AND status = 'active'")
+    .bind(id, user.id)
+    .first<SubdomainRecord>();
+  if (!owned) return NextResponse.json({ error: 'Active subdomain not found' }, { status: 404 });
+
+  await db.batch([
+    db.prepare('UPDATE subdomains SET is_default = 0 WHERE user_id = ? AND is_default = 1').bind(user.id),
+    db.prepare("UPDATE subdomains SET is_default = 1, updated_at = datetime('now') WHERE id = ? AND user_id = ?").bind(id, user.id),
+  ]);
+  const updated = { ...owned, is_default: 1 };
+  auditLog(user.id, 'subdomain.default', 'subdomain', String(id), owned.hostname).catch(() => {});
+  return NextResponse.json({ subdomain: publicSubdomain(updated) });
+}
+
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const csrfError = requireSameOrigin(request);
+  if (csrfError) return csrfError;
+  const user = await resolveUser(request, 'write');
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  const id = Number((await params).id);
+  if (!Number.isSafeInteger(id) || id < 1) return NextResponse.json({ error: 'Invalid subdomain id' }, { status: 400 });
+
+  const db = getDB();
+  const removed = await db
+    .prepare(
+      `UPDATE subdomains
+       SET status = 'removed', is_default = 0, removed_at = datetime('now'),
+           revision = revision + 1, updated_at = datetime('now')
+       WHERE id = ? AND user_id = ? AND status != 'removed'
+       RETURNING *`,
+    )
+    .bind(id, user.id)
+    .first<SubdomainRecord>();
+  if (!removed) return NextResponse.json({ error: 'Subdomain not found' }, { status: 404 });
+
+  auditLog(user.id, 'subdomain.remove', 'subdomain', String(id), removed.hostname).catch(() => {});
+  return NextResponse.json({ success: true });
+}

--- a/app/api/subdomains/[id]/verify/route.ts
+++ b/app/api/subdomains/[id]/verify/route.ts
@@ -1,0 +1,81 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { auditLog, resolveUser } from '@/lib/auth';
+import { requireSameOrigin } from '@/lib/csrf';
+import { getDB } from '@/lib/db';
+import { publicSubdomain } from '@/lib/subdomain-control';
+import { generateVerificationToken, subdomainEntitlement, verificationExpiry } from '@/lib/subdomains';
+import type { SubdomainRecord } from '@/lib/types';
+
+export const runtime = 'edge';
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const csrfError = requireSameOrigin(request);
+  if (csrfError) return csrfError;
+  const user = await resolveUser(request, 'write');
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  if (subdomainEntitlement(user.tier) === 0) {
+    return NextResponse.json({ error: 'An active paid plan is required' }, { status: 403 });
+  }
+
+  const id = Number((await params).id);
+  if (!Number.isSafeInteger(id) || id < 1) return NextResponse.json({ error: 'Invalid subdomain id' }, { status: 400 });
+  const db = getDB();
+  let record = await db
+    .prepare("SELECT * FROM subdomains WHERE id = ? AND user_id = ? AND status IN ('pending', 'failed', 'verified', 'suspended')")
+    .bind(id, user.id)
+    .first<SubdomainRecord>();
+  if (!record) return NextResponse.json({ error: 'Subdomain cannot be verified' }, { status: 404 });
+
+  if (Date.parse(record.verification_expires_at) <= Date.now()) {
+    record = await db
+      .prepare(
+        `UPDATE subdomains SET status = 'pending', verification_token = ?,
+         verification_expires_at = ?, last_error = NULL, updated_at = datetime('now')
+         WHERE id = ? RETURNING *`,
+      )
+      .bind(generateVerificationToken(), verificationExpiry(), id)
+      .first<SubdomainRecord>();
+  }
+
+  let verified = false;
+  let failure = 'Wildcard DNS, TLS, or the subdomain router is not ready';
+  try {
+    const response = await fetch(`https://${record!.hostname}/.well-known/lixrl-domain-challenge`, {
+      headers: { 'X-LixRL-Verification-Token': record!.verification_token },
+      redirect: 'manual',
+    });
+    const result = await response.json().catch(() => null) as { verified?: boolean } | null;
+    verified = response.ok && result?.verified === true;
+    if (!verified && result && 'error' in result) failure = 'Subdomain router rejected verification';
+  } catch {
+    verified = false;
+  }
+
+  if (!verified) {
+    const failed = await db
+      .prepare("UPDATE subdomains SET status = 'failed', last_error = ?, updated_at = datetime('now') WHERE id = ? RETURNING *")
+      .bind(failure, id)
+      .first<SubdomainRecord>();
+    return NextResponse.json({ error: failure, subdomain: publicSubdomain(failed!) }, { status: 409 });
+  }
+
+  const hasDefault = await db
+    .prepare("SELECT id FROM subdomains WHERE user_id = ? AND is_default = 1 AND status = 'active' LIMIT 1")
+    .bind(user.id)
+    .first();
+  const active = await db
+    .prepare(
+      `UPDATE subdomains
+       SET status = 'active', verified_at = datetime('now'), activated_at = datetime('now'),
+           is_default = ?, last_error = NULL, revision = revision + 1,
+           updated_at = datetime('now')
+       WHERE id = ? RETURNING *`,
+    )
+    .bind(hasDefault ? 0 : 1, id)
+    .first<SubdomainRecord>();
+  auditLog(user.id, 'subdomain.activate', 'subdomain', String(id), active!.hostname).catch(() => {});
+  return NextResponse.json({ subdomain: publicSubdomain(active!) });
+}

--- a/app/api/subdomains/route.ts
+++ b/app/api/subdomains/route.ts
@@ -1,0 +1,84 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { auditLog, resolveUser } from '@/lib/auth';
+import { requireSameOrigin } from '@/lib/csrf';
+import { getDB } from '@/lib/db';
+import { rateLimit } from '@/lib/ratelimit';
+import { publicSubdomain } from '@/lib/subdomain-control';
+import {
+  generateVerificationToken,
+  normalizeSubdomainLabel,
+  subdomainEntitlement,
+  subdomainHostname,
+  validateSubdomainLabel,
+  verificationExpiry,
+} from '@/lib/subdomains';
+import type { SubdomainRecord } from '@/lib/types';
+
+export const runtime = 'edge';
+
+export async function GET(request: NextRequest) {
+  const user = await resolveUser(request);
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const { results } = await getDB()
+    .prepare(
+      `SELECT * FROM subdomains
+       WHERE user_id = ? AND status != 'removed'
+       ORDER BY is_default DESC, created_at ASC`,
+    )
+    .bind(user.id)
+    .all<SubdomainRecord>();
+
+  return NextResponse.json({
+    subdomains: (results || []).map(publicSubdomain),
+    entitlement: subdomainEntitlement(user.tier),
+  });
+}
+
+export async function POST(request: NextRequest) {
+  const csrfError = requireSameOrigin(request);
+  if (csrfError) return csrfError;
+  const limited = await rateLimit(request, 'subdomain:create', 5, 60);
+  if (limited) return limited;
+
+  const user = await resolveUser(request, 'write');
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const allowance = subdomainEntitlement(user.tier);
+  if (allowance === 0) {
+    return NextResponse.json({ error: 'Subdomains require Pro or above' }, { status: 403 });
+  }
+
+  const body = await request.json().catch(() => null) as { label?: unknown } | null;
+  if (!body) return NextResponse.json({ error: 'Request body must be valid JSON' }, { status: 400 });
+  const labelError = validateSubdomainLabel(body.label);
+  if (labelError) return NextResponse.json({ error: labelError }, { status: 400 });
+
+  const db = getDB();
+  if (allowance !== -1) {
+    const count = await db
+      .prepare("SELECT COUNT(*) AS count FROM subdomains WHERE user_id = ? AND status != 'removed'")
+      .bind(user.id)
+      .first<{ count: number }>();
+    if ((count?.count || 0) >= allowance) {
+      return NextResponse.json({ error: `Your ${user.tier} plan includes ${allowance} subdomain${allowance === 1 ? '' : 's'}` }, { status: 403 });
+    }
+  }
+
+  const label = normalizeSubdomainLabel(body.label);
+  const hostname = subdomainHostname(label);
+  try {
+    const record = await db
+      .prepare(
+        `INSERT INTO subdomains
+          (user_id, label, hostname, verification_token, verification_expires_at)
+         VALUES (?, ?, ?, ?, ?) RETURNING *`,
+      )
+      .bind(user.id, label, hostname, generateVerificationToken(), verificationExpiry())
+      .first<SubdomainRecord>();
+    auditLog(user.id, 'subdomain.claim', 'subdomain', String(record!.id), hostname).catch(() => {});
+    return NextResponse.json({ subdomain: publicSubdomain(record!) }, { status: 201 });
+  } catch {
+    return NextResponse.json({ error: 'This subdomain is already claimed' }, { status: 409 });
+  }
+}

--- a/app/api/urls/[code]/route.ts
+++ b/app/api/urls/[code]/route.ts
@@ -6,6 +6,7 @@ import { validateUrl, validateLength, validateFutureDate, badRequest } from '@/l
 import { TIER_LIMITS, type UrlRecord } from '@/lib/types';
 import { checkSafeBrowsing, threatMessage } from '@/lib/safebrowsing';
 import { putRedirectCache } from '@/lib/redirect-cache';
+import { bumpSubdomainRevisionsForUrl } from '@/lib/subdomain-control';
 
 export const runtime = 'edge';
 
@@ -100,6 +101,7 @@ export async function PATCH(request: NextRequest, { params }: { params: Promise<
 
   await db.prepare(`UPDATE urls SET ${updates.join(', ')} WHERE short_code = ? AND user_id = ?`)
     .bind(...bindParams).run();
+  await bumpSubdomainRevisionsForUrl(db, url.id);
 
   // Sync KV cache
   const newUrl = body.url || url.original_url;
@@ -131,9 +133,10 @@ export async function DELETE(request: NextRequest, { params }: { params: Promise
   const kv = getKV();
 
   const url = await db.prepare('SELECT id FROM urls WHERE short_code = ? AND user_id = ?')
-    .bind(code, user.id).first();
+    .bind(code, user.id).first<{ id: number }>();
   if (!url) return NextResponse.json({ error: 'Not found' }, { status: 404 });
 
+  await bumpSubdomainRevisionsForUrl(db, url.id);
   await db.prepare('DELETE FROM urls WHERE short_code = ? AND user_id = ?').bind(code, user.id).run();
   kv.delete(`url:${code}`).catch(() => {});
   auditLog(user.id, 'url.delete', 'url', code).catch(() => {});

--- a/app/api/urls/bulk-delete/route.ts
+++ b/app/api/urls/bulk-delete/route.ts
@@ -59,6 +59,19 @@ export async function POST(request: NextRequest) {
   // Single DELETE with IN(...) on owner — D1 prepares parameter binding
   // up to a reasonable limit; MAX_BULK keeps us well clear.
   const placeholders = unique.map(() => '?').join(',');
+  await db
+    .prepare(
+      `UPDATE subdomains
+       SET revision = revision + 1, updated_at = datetime('now')
+       WHERE id IN (
+         SELECT DISTINCT dl.subdomain_id
+         FROM subdomain_links dl
+         JOIN urls u ON u.id = dl.url_id
+         WHERE u.user_id = ? AND u.short_code IN (${placeholders})
+       )`,
+    )
+    .bind(user.id, ...unique)
+    .run();
   const result = await db
     .prepare(
       `DELETE FROM urls WHERE user_id = ? AND short_code IN (${placeholders})`,

--- a/app/api/webhooks/pay/route.ts
+++ b/app/api/webhooks/pay/route.ts
@@ -235,6 +235,22 @@ async function applyEntitlement(data: EntitlementData): Promise<void> {
     )
     .bind(tier, status, expiresAt, subId, data.uid)
     .run();
+
+  // D1 remains authoritative for branded routing. A lapse suspends every
+  // claimed hostname immediately; a later renewal leaves reactivation as an
+  // explicit owner action so a stale claim can never silently come back.
+  if (!granting) {
+    await db
+      .prepare(
+        `UPDATE subdomains
+         SET status = 'suspended', is_default = 0, revision = revision + 1,
+             last_error = 'Paid plan inactive', updated_at = datetime('now')
+         WHERE user_id = (SELECT id FROM users WHERE elixpo_id = ?)
+           AND status IN ('pending', 'verified', 'active', 'failed')`,
+      )
+      .bind(data.uid)
+      .run();
+  }
 }
 
 function billingStatusFor(s?: string, failed?: boolean): BillingStatus {

--- a/app/components/Sidebar.tsx
+++ b/app/components/Sidebar.tsx
@@ -27,6 +27,12 @@ const Icons = {
       <path d="M11.5 8.5a4 4 0 00-5.5 0L3.5 11a4 4 0 005.5 5.5l1.5-1.5" />
     </svg>
   ),
+  domain: (
+    <svg viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" className="w-[18px] h-[18px]">
+      <circle cx="10" cy="10" r="7.5" />
+      <path d="M2.5 10h15M10 2.5c2 2.1 3 4.6 3 7.5s-1 5.4-3 7.5M10 2.5C8 4.6 7 7.1 7 10s1 5.4 3 7.5" />
+    </svg>
+  ),
   plus: (
     <svg viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" className="w-[18px] h-[18px]">
       <circle cx="10" cy="10" r="7.5" />
@@ -103,6 +109,7 @@ const navItems = [
   { href: '/dashboard', label: 'Dashboard', icon: Icons.dashboard },
   { href: '/dashboard/urls', label: 'My URLs', icon: Icons.link },
   { href: '/dashboard/new', label: 'Shorten URL', icon: Icons.plus },
+  { href: '/dashboard/domains', label: 'Subdomains', icon: Icons.domain },
 ];
 
 const accountItems = [

--- a/app/dashboard/domains/DomainsClient.tsx
+++ b/app/dashboard/domains/DomainsClient.tsx
@@ -1,0 +1,200 @@
+'use client';
+
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { useState } from 'react';
+import type { PublicSubdomain } from '@/lib/subdomain-control';
+import type { Tier } from '@/lib/types';
+
+export interface DomainLinkView {
+  subdomain_id: number;
+  short_code: string;
+  fallback_code: string;
+  title: string | null;
+  original_url: string;
+}
+
+interface UrlChoice {
+  short_code: string;
+  title: string | null;
+  original_url: string;
+}
+
+export default function DomainsClient({
+  tier,
+  allowance,
+  domains,
+  urls,
+  links,
+}: {
+  tier: Tier;
+  allowance: number;
+  domains: PublicSubdomain[];
+  urls: UrlChoice[];
+  links: DomainLinkView[];
+}) {
+  const router = useRouter();
+  const [label, setLabel] = useState('');
+  const [busy, setBusy] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [mapping, setMapping] = useState<Record<number, { url: string; code: string }>>({});
+  const canClaim = allowance === -1 || domains.length < allowance;
+
+  const mutate = async (key: string, endpoint: string, init: RequestInit) => {
+    setBusy(key);
+    setError(null);
+    try {
+      const response = await fetch(endpoint, init);
+      const data = await response.json().catch(() => null) as { error?: string } | null;
+      if (!response.ok) throw new Error(data?.error || 'Request failed');
+      router.refresh();
+      return true;
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : 'Request failed');
+      return false;
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const claim = async () => {
+    const ok = await mutate('claim', '/api/subdomains', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ label }),
+    });
+    if (ok) setLabel('');
+  };
+
+  if (allowance === 0) {
+    return (
+      <div className="mx-auto w-full max-w-5xl px-2 py-2">
+        <h1 className="text-2xl font-bold text-[#111]">Branded subdomains</h1>
+        <div className="mt-6 rounded-2xl border border-[#f0c8c6] bg-[#fff7f6] p-6 md:p-8">
+          <p className="text-xs font-bold uppercase tracking-[0.12em] text-[#c62828]">Paid feature</p>
+          <h2 className="mt-2 text-2xl font-bold text-[#111]">Publish on your own lixrl.com subdomain</h2>
+          <p className="mt-3 max-w-2xl text-sm leading-6 text-[#666]">
+            Pro includes one single-level subdomain; Business includes three. Each has isolated codes, TLS, analytics, and a canonical lixrl.com fallback.
+          </p>
+          <Link href="/pricing" className="mt-5 inline-flex rounded-full bg-[#111] px-5 py-2.5 text-sm font-bold text-white no-underline">
+            Compare paid plans
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto w-full max-w-6xl px-2 py-2">
+      <div className="flex flex-col justify-between gap-4 md:flex-row md:items-end">
+        <div>
+          <p className="text-xs font-bold uppercase tracking-[0.12em] text-[#c62828]">{tier} entitlement</p>
+          <h1 className="mt-1 text-2xl font-bold text-[#111]">Branded subdomains</h1>
+          <p className="mt-2 text-sm text-[#666]">Reserve one DNS label under lixrl.com, verify the wildcard route, then map your links.</p>
+        </div>
+        <div className="rounded-full border border-[#ddd] px-4 py-2 text-xs font-semibold text-[#555]">
+          {domains.length} / {allowance === -1 ? 'Unlimited' : allowance} claimed
+        </div>
+      </div>
+
+      {error && <div className="mt-5 rounded-xl border border-[#efb5b2] bg-[#fff5f4] px-4 py-3 text-sm text-[#a42622]">{error}</div>}
+
+      <section className="mt-6 rounded-2xl border border-[#e5e5e5] bg-[#fafafa] p-5">
+        <label htmlFor="subdomain-label" className="text-sm font-bold text-[#111]">Claim a subdomain</label>
+        <div className="mt-3 flex flex-col gap-3 sm:flex-row">
+          <div className="flex flex-1 items-center overflow-hidden rounded-xl border border-[#d8d8d8] bg-white focus-within:border-[#e53935]">
+            <input
+              id="subdomain-label"
+              value={label}
+              onChange={(event) => setLabel(event.target.value.toLowerCase().replace(/[^a-z0-9-]/g, ''))}
+              placeholder="your-brand"
+              maxLength={32}
+              disabled={!canClaim || busy !== null}
+              className="min-w-0 flex-1 border-0 bg-transparent px-4 py-3 text-sm text-[#111] outline-none"
+            />
+            <span className="border-l border-[#e5e5e5] bg-[#f7f7f7] px-4 py-3 font-mono text-sm text-[#777]">.lixrl.com</span>
+          </div>
+          <button
+            type="button"
+            onClick={claim}
+            disabled={!canClaim || !label || busy !== null}
+            className="rounded-xl bg-[#111] px-5 py-3 text-sm font-bold text-white disabled:cursor-not-allowed disabled:opacity-40"
+          >
+            {busy === 'claim' ? 'Claiming…' : 'Claim'}
+          </button>
+        </div>
+        <p className="mt-2 text-xs text-[#777]">3–32 lowercase letters, numbers, or interior hyphens. Reserved product labels cannot be claimed.</p>
+      </section>
+
+      <div className="mt-6 space-y-5">
+        {domains.map((domain) => {
+          const domainLinks = links.filter((link) => link.subdomain_id === domain.id);
+          const draft = mapping[domain.id] || { url: urls[0]?.short_code || '', code: '' };
+          const active = domain.status === 'active';
+          return (
+            <section key={domain.id} className="rounded-2xl border border-[#e5e5e5] bg-white p-5 shadow-sm md:p-6">
+              <div className="flex flex-col justify-between gap-4 sm:flex-row sm:items-start">
+                <div>
+                  <div className="flex flex-wrap items-center gap-2">
+                    <a href={`https://${domain.hostname}`} className="font-mono text-lg font-bold text-[#111] no-underline hover:text-[#c62828]">{domain.hostname}</a>
+                    <StatusBadge status={domain.status} />
+                    {!!domain.is_default && <span className="rounded-full bg-[#111] px-2.5 py-1 text-[10px] font-bold uppercase tracking-wide text-white">Default</span>}
+                  </div>
+                  <p className="mt-2 text-xs text-[#777]">
+                    {active ? 'TLS and routing verified. New links use this domain when it is the default.' : domain.last_error || 'Waiting for wildcard DNS and TLS route verification.'}
+                  </p>
+                </div>
+                <div className="flex flex-wrap gap-2">
+                  {!active && domain.status !== 'removed' && (
+                    <button type="button" disabled={busy !== null} onClick={() => mutate(`verify-${domain.id}`, `/api/subdomains/${domain.id}/verify`, { method: 'POST' })} className="rounded-lg bg-[#e53935] px-3 py-2 text-xs font-bold text-white disabled:opacity-50">
+                      {busy === `verify-${domain.id}` ? 'Verifying…' : 'Verify route'}
+                    </button>
+                  )}
+                  {active && !domain.is_default && (
+                    <button type="button" disabled={busy !== null} onClick={() => mutate(`default-${domain.id}`, `/api/subdomains/${domain.id}`, { method: 'PATCH', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ is_default: true }) })} className="rounded-lg border border-[#d5d5d5] px-3 py-2 text-xs font-semibold text-[#444] disabled:opacity-50">Make default</button>
+                  )}
+                  <button type="button" disabled={busy !== null} onClick={() => window.confirm(`Remove ${domain.hostname}? Its branded links will stop immediately.`) && mutate(`remove-${domain.id}`, `/api/subdomains/${domain.id}`, { method: 'DELETE' })} className="rounded-lg border border-[#efc1bf] px-3 py-2 text-xs font-semibold text-[#b32622] disabled:opacity-50">Remove</button>
+                </div>
+              </div>
+
+              {active && (
+                <div className="mt-6 border-t border-[#ececec] pt-5">
+                  <h3 className="text-sm font-bold text-[#111]">Map a link</h3>
+                  <div className="mt-3 grid gap-2 md:grid-cols-[minmax(0,1fr)_minmax(180px,0.7fr)_auto]">
+                    <select value={draft.url} onChange={(event) => setMapping((current) => ({ ...current, [domain.id]: { ...draft, url: event.target.value } }))} className="rounded-lg border border-[#ddd] bg-white px-3 py-2.5 text-sm text-[#333]">
+                      {urls.map((url) => <option key={url.short_code} value={url.short_code}>{url.title || url.short_code} · /{url.short_code}</option>)}
+                    </select>
+                    <input value={draft.code} onChange={(event) => setMapping((current) => ({ ...current, [domain.id]: { ...draft, code: event.target.value.toLowerCase().replace(/[^a-z0-9_-]/g, '') } }))} placeholder="Branded code (optional)" className="rounded-lg border border-[#ddd] px-3 py-2.5 text-sm text-[#333]" />
+                    <button type="button" disabled={!draft.url || busy !== null} onClick={() => mutate(`map-${domain.id}`, `/api/subdomains/${domain.id}/links`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ url_code: draft.url, short_code: draft.code || undefined }) })} className="rounded-lg bg-[#111] px-4 py-2.5 text-sm font-bold text-white disabled:opacity-40">Map</button>
+                  </div>
+
+                  <div className="mt-4 space-y-2">
+                    {domainLinks.map((link) => (
+                      <div key={link.short_code} className="flex flex-col justify-between gap-3 rounded-xl bg-[#fafafa] px-4 py-3 sm:flex-row sm:items-center">
+                        <div className="min-w-0">
+                          <a href={`https://${domain.hostname}/${link.short_code}`} className="truncate font-mono text-sm font-bold text-[#c62828]">{domain.hostname}/{link.short_code}</a>
+                          <p className="mt-1 truncate text-xs text-[#777]">Fallback: lixrl.com/{link.fallback_code} · {link.original_url}</p>
+                        </div>
+                        <button type="button" disabled={busy !== null} onClick={() => mutate(`unlink-${domain.id}-${link.short_code}`, `/api/subdomains/${domain.id}/links/${encodeURIComponent(link.short_code)}`, { method: 'DELETE' })} className="text-xs font-semibold text-[#b32622]">Unmap</button>
+                      </div>
+                    ))}
+                    {domainLinks.length === 0 && <p className="rounded-xl bg-[#fafafa] px-4 py-4 text-sm text-[#777]">No links mapped yet. New links will map automatically when this is your default domain.</p>}
+                  </div>
+                </div>
+              )}
+            </section>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function StatusBadge({ status }: { status: PublicSubdomain['status'] }) {
+  const active = status === 'active';
+  return (
+    <span className="rounded-full px-2.5 py-1 text-[10px] font-bold uppercase tracking-wide" style={{ background: active ? '#eaf8ef' : '#fff3df', color: active ? '#17743a' : '#9a5a00' }}>
+      {status}
+    </span>
+  );
+}

--- a/app/dashboard/domains/page.tsx
+++ b/app/dashboard/domains/page.tsx
@@ -1,0 +1,40 @@
+import { getCurrentUser } from '@/lib/auth';
+import { getDB } from '@/lib/db';
+import { publicSubdomain } from '@/lib/subdomain-control';
+import { subdomainEntitlement } from '@/lib/subdomains';
+import type { SubdomainRecord } from '@/lib/types';
+import DomainsClient, { type DomainLinkView } from './DomainsClient';
+
+export const runtime = 'edge';
+
+export default async function DomainsPage() {
+  const user = (await getCurrentUser())!;
+  const db = getDB();
+  const [{ results: domains }, { results: urls }, { results: links }] = await Promise.all([
+    db.prepare(
+      `SELECT * FROM subdomains WHERE user_id = ? AND status != 'removed'
+       ORDER BY is_default DESC, created_at ASC`,
+    ).bind(user.id).all<SubdomainRecord>(),
+    db.prepare('SELECT short_code, title, original_url FROM urls WHERE user_id = ? ORDER BY created_at DESC LIMIT 250')
+      .bind(user.id).all<{ short_code: string; title: string | null; original_url: string }>(),
+    db.prepare(
+      `SELECT dl.subdomain_id, dl.short_code, u.short_code AS fallback_code,
+              u.title, u.original_url
+       FROM subdomain_links dl
+       JOIN subdomains s ON s.id = dl.subdomain_id
+       JOIN urls u ON u.id = dl.url_id
+       WHERE s.user_id = ? AND s.status != 'removed'
+       ORDER BY dl.created_at DESC`,
+    ).bind(user.id).all<DomainLinkView>(),
+  ]);
+
+  return (
+    <DomainsClient
+      tier={user.tier}
+      allowance={subdomainEntitlement(user.tier)}
+      domains={(domains || []).map(publicSubdomain)}
+      urls={urls || []}
+      links={links || []}
+    />
+  );
+}

--- a/app/docs/layout.tsx
+++ b/app/docs/layout.tsx
@@ -16,6 +16,7 @@ const DOCS_NAV = [
   { label: 'Shortening API', href: '/docs/api' },
   { label: 'API Keys', href: '/docs/keys' },
   { label: 'Click Analytics', href: '/docs/analytics' },
+  { label: 'Branded Subdomains', href: '/docs/subdomains' },
   { label: 'Webhooks', href: '/docs/webhooks' },
   { label: 'Error Reference', href: '/docs/errors' },
   { label: 'Self-Hosting', href: '/docs/self-hosting' },

--- a/app/docs/subdomains/page.tsx
+++ b/app/docs/subdomains/page.tsx
@@ -1,0 +1,69 @@
+import Link from 'next/link';
+
+export const runtime = 'edge';
+
+const H1 = 'text-3xl md:text-4xl font-extrabold tracking-tight text-[#111]';
+const H2 = 'text-2xl font-bold tracking-tight text-[#111] mt-10 mb-4';
+const P = 'text-[#555] leading-7 mb-4';
+const CODE = 'rounded-xl bg-[#171717] p-4 font-mono text-sm text-[#f5f5f4] overflow-x-auto';
+
+export default function SubdomainsDocsPage() {
+  return (
+    <div>
+      <h1 className={H1}>Branded subdomains</h1>
+      <p className="mt-4 text-lg leading-8 text-[#555]">
+        Publish paid-plan links at a single-level address such as <code>brand.lixrl.com/go</code> while keeping a canonical <code>lixrl.com</code> fallback.
+      </p>
+
+      <h2 id="availability" className={H2}>Availability and limits</h2>
+      <ul className="ml-5 list-disc space-y-2 text-[#555]">
+        <li>Pro includes one branded subdomain.</li>
+        <li>Business includes three; Enterprise limits are arranged separately.</li>
+        <li>Free accounts cannot claim or activate subdomains.</li>
+        <li>Labels are 3–32 lowercase letters, numbers, or interior hyphens with no additional dots.</li>
+      </ul>
+
+      <h2 id="setup" className={H2}>Setup</h2>
+      <ol className="ml-5 list-decimal space-y-3 text-[#555]">
+        <li>Open <Link href="/dashboard/domains" className="text-[#c62828] underline">Dashboard → Subdomains</Link>.</li>
+        <li>Claim an available label. Claims are atomic; another account cannot hold the same live hostname.</li>
+        <li>Select <strong>Verify route</strong>. LixRL checks wildcard DNS, TLS, the redirect Worker, and the claim token over HTTPS.</li>
+        <li>Make the verified hostname your default or map individual existing links to branded codes.</li>
+      </ol>
+      <p className={`${P} mt-4`}>No customer DNS changes are required because the hostname remains under lixrl.com.</p>
+
+      <h2 id="api" className={H2}>API workflow</h2>
+      <pre className={CODE}>{`# Claim
+curl -X POST https://lixrl.com/api/subdomains \\
+  -H "Authorization: Bearer elu_YOUR_API_KEY" \\
+  -H "Content-Type: application/json" \\
+  -d '{"label":"brand"}'
+
+# Verify wildcard routing and TLS
+curl -X POST https://lixrl.com/api/subdomains/42/verify \\
+  -H "Authorization: Bearer elu_YOUR_API_KEY"
+
+# Map an owned fallback link to a domain-specific code
+curl -X POST https://lixrl.com/api/subdomains/42/links \\
+  -H "Authorization: Bearer elu_YOUR_API_KEY" \\
+  -H "Content-Type: application/json" \\
+  -d '{"url_code":"a1b2c3","short_code":"launch"}'`}</pre>
+
+      <h2 id="routing" className={H2}>Routing and isolation</h2>
+      <p className={P}>
+        Branded links are resolved by hostname and code. The same code can belong to different verified subdomains. D1 checks ownership, plan status, domain state, and link state before a cached redirect is used; cache keys include both the domain ID and its revision.
+      </p>
+      <p className={P}>
+        Destination safety checks, expiry, bot filtering, click analytics, QR destinations, and API ownership rules remain the same as canonical links.
+      </p>
+
+      <h2 id="lifecycle" className={H2}>Removal, downgrade, and recovery</h2>
+      <p className={P}>
+        Removing a claim or losing the paid entitlement disables branded routing and increments its route revision immediately. Canonical <code>lixrl.com/code</code> links continue to work. A renewed account must verify and reactivate a suspended claim explicitly.
+      </p>
+      <p className={P}>
+        A failed verification normally means wildcard DNS, certificate issuance, or the router deployment is not ready. Wait for propagation, retry verification, and check the production deployment logs. Removed names require a fresh claim and verification before reuse.
+      </p>
+    </div>
+  );
+}

--- a/app/pricing/page.tsx
+++ b/app/pricing/page.tsx
@@ -27,6 +27,7 @@ const COMPARISON_ROWS: { label: string; values: Record<SellableTier, string> }[]
   { label: 'New-link allowance', values: { free: '2 per UTC day', pro: 'Up to plan limit', business: 'Up to plan limit' } },
   { label: 'Analytics', values: { free: 'Click totals · 7 days', pro: 'Geo, device & CSV · 30 days', business: 'Geo, device & CSV · 1 year' } },
   { label: 'Custom slugs', values: { free: '—', pro: 'Included', business: 'Included' } },
+  { label: 'Branded lixrl.com subdomains', values: { free: '—', pro: '1', business: '3' } },
   { label: 'API keys', values: { free: '1', pro: '5', business: '20' } },
   { label: 'Expiring links', values: { free: '—', pro: 'Included', business: 'Included' } },
   { label: 'QR customization', values: { free: '3 presets', pro: 'All presets + logo', business: 'All presets + logo' } },
@@ -48,6 +49,7 @@ function featuresFor(tier: SellableTier): string[] {
   out.push(l.customCodes ? 'Custom slugs' : 'Auto-generated slugs');
   out.push(l.analytics ? 'Geo / device analytics + CSV' : 'Click totals');
   if (l.expiringLinks) out.push('Expiring links');
+  if (l.brandedDomains > 0) out.push(`${l.brandedDomains} branded lixrl.com subdomain${l.brandedDomains === 1 ? '' : 's'}`);
   if (l.qrLogo) out.push('Custom QR logos and styles');
   return out;
 }
@@ -431,8 +433,8 @@ export default function PricingPage() {
             <Faq question="How does annual billing work?">
               Annual prices cover 12 months and cost about the same as 10 monthly payments. The exact annual total and monthly equivalent are shown above before checkout.
             </Faq>
-            <Faq question="Are custom domains included?">
-              Not yet. Custom-domain and subdomain routing are intentionally excluded until domain verification, TLS, tenant routing, and takeover protection are complete.
+            <Faq question="Are branded subdomains included?">
+              Yes. Pro includes one and Business includes three single-level addresses such as your-brand.lixrl.com. External domains are not included yet.
             </Faq>
             <Faq question="Can I cancel a paid plan?">
               You can stop renewal at any time. Paid access continues through the current billing period unless the checkout terms state otherwise.

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -59,7 +59,7 @@ export default function PrivacyPage() {
 
       <LegalSection id="accounts" title="4. Accounts, links, and billing">
         <p>Elixpo Accounts provides authentication. We receive and store an opaque Elixpo account ID, email address, display name, avatar URL when available, account role, tier, and session records. We do not receive or store your password.</p>
-        <p>We store the destinations, short codes, titles, campaign labels, tags, expiry settings, and active state you choose. API keys are stored as hashes; the full key is shown only when created. For paid plans, we retain subscription identifiers and billing status needed to apply entitlements. Payment details are handled by the checkout provider and are not stored in LixRL’s database.</p>
+        <p>We store the destinations, short codes, titles, campaign labels, tags, expiry settings, branded subdomain claims and mappings, and active state you choose. API keys are stored as hashes; the full key is shown only when created. For paid plans, we retain subscription identifiers and billing status needed to apply entitlements. Payment details are handled by the checkout provider and are not stored in LixRL’s database.</p>
       </LegalSection>
 
       <LegalSection id="use-and-sharing" title="5. How data is used and shared">

--- a/app/terms/page.tsx
+++ b/app/terms/page.tsx
@@ -55,7 +55,7 @@ export default function TermsPage() {
 
       <LegalSection id="links-and-content" title="3. Your links and acceptable use">
         <p>
-          You retain ownership of destination URLs, titles, campaign labels, and tags you submit. You give us the limited permission needed to store that information, resolve the short link, provide analytics, and operate the service.
+          You retain ownership of destination URLs, titles, campaign labels, tags, and eligible subdomain labels you submit. You give us the limited permission needed to store that information, resolve the short link, provide analytics, and operate the service.
         </p>
         <p>You must not use LixRL to:</p>
         <ul>
@@ -70,7 +70,7 @@ export default function TermsPage() {
       </LegalSection>
 
       <LegalSection id="plans-and-billing" title="4. Plans, quotas, and billing">
-        <p>Current prices and enforced feature limits appear on the <a href="/pricing">Pricing page</a>. Limits can include stored links, daily creation, analytics retention, API keys, custom slugs, expiring links, and QR options.</p>
+        <p>Current prices and enforced feature limits appear on the <a href="/pricing">Pricing page</a>. Limits can include stored links, daily creation, analytics retention, API keys, branded lixrl.com subdomains, custom slugs, expiring links, and QR options.</p>
         <ul>
           <li>Paid subscriptions renew for the selected monthly or annual period until cancelled.</li>
           <li>Cancellation stops the next renewal; access continues through the paid period unless otherwise stated at checkout.</li>

--- a/deploy.sh
+++ b/deploy.sh
@@ -5,6 +5,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT="elixpourl"
 OUTDIR=".vercel/output/static"
 WRANGLER_CONFIG="$SCRIPT_DIR/wrangler.toml"
+SUBDOMAIN_WRANGLER_CONFIG="$SCRIPT_DIR/wrangler.subdomains.toml"
 
 # CF Pages treats `main` as Production. Without --branch, wrangler tags the
 # deploy as Preview for whatever git branch you're on — which never updates
@@ -23,6 +24,7 @@ usage() {
   echo "Commands (can be chained):"
   echo "  build     Build the Next.js app with @cloudflare/next-on-pages"
   echo "  deploy    Deploy to Cloudflare Pages (builds first if needed)"
+  echo "            Production also deploys the *.lixrl.com redirect Worker"
   echo "  all       Build and deploy in one step"
   echo "  migrate   Run D1 database migrations (remote)"
   echo "  secrets   Decrypt .env (sops) and upload all secrets to Pages prod"
@@ -65,6 +67,10 @@ check_deps() {
 
   if [ ! -f "$WRANGLER_CONFIG" ]; then
     err "Wrangler config not found: $WRANGLER_CONFIG"
+    exit 1
+  fi
+  if [ ! -f "$SUBDOMAIN_WRANGLER_CONFIG" ]; then
+    err "Subdomain Wrangler config not found: $SUBDOMAIN_WRANGLER_CONFIG"
     exit 1
   fi
 }
@@ -143,6 +149,12 @@ do_deploy() {
     --config="$WRANGLER_CONFIG" \
     --project-name="$PROJECT" \
     --branch="$BRANCH"
+  if [ "$BRANCH" = "main" ]; then
+    log "Deploying the ${BOLD}*.lixrl.com${RESET} redirect Worker..."
+    npx wrangler deploy --config="$SUBDOMAIN_WRANGLER_CONFIG"
+  else
+    dim "Skipping wildcard subdomain Worker for preview branch."
+  fi
   log "Deploy complete"
 }
 
@@ -231,6 +243,11 @@ do_secrets() {
     dim "set $k"
     count=$((count + 1))
   done
+  if [ -n "${vars[GUEST_FINGERPRINT_SECRET]:-}" ]; then
+    printf '%s' "${vars[GUEST_FINGERPRINT_SECRET]}" | npx wrangler secret put \
+      GUEST_FINGERPRINT_SECRET --config="$SUBDOMAIN_WRANGLER_CONFIG" >/dev/null
+    dim "set GUEST_FINGERPRINT_SECRET on lixrl-subdomain-router"
+  fi
   log "Uploaded $count secrets"
   dim "Secrets apply to the next deploy — run: ./deploy.sh deploy"
 }

--- a/lib/create-url.ts
+++ b/lib/create-url.ts
@@ -3,6 +3,7 @@ import { auditLog } from '@/lib/auth';
 import { getDB, getEnv, getKV } from '@/lib/db';
 import { checkSafeBrowsing, threatMessage } from '@/lib/safebrowsing';
 import { putRedirectCache } from '@/lib/redirect-cache';
+import { bumpSubdomainRevision } from '@/lib/subdomain-control';
 import {
   claimFreeCreation,
   releaseFreeCreation,
@@ -188,10 +189,29 @@ export async function createUrlForUser(
     id: result!.id,
     expires_at: expiry,
   }).catch(() => {});
+  const defaultSubdomain = await db
+    .prepare("SELECT id, hostname FROM subdomains WHERE user_id = ? AND is_default = 1 AND status = 'active' LIMIT 1")
+    .bind(user.id)
+    .first<{ id: number; hostname: string }>();
+  let brandedUrl: string | null = null;
+  if (defaultSubdomain) {
+    try {
+      await db
+        .prepare('INSERT INTO subdomain_links (subdomain_id, url_id, short_code) VALUES (?, ?, ?)')
+        .bind(defaultSubdomain.id, result!.id, shortCode)
+        .run();
+      await bumpSubdomainRevision(db, defaultSubdomain.id);
+      brandedUrl = `https://${defaultSubdomain.hostname}/${shortCode}`;
+    } catch {
+      // A manually assigned branded code may already occupy this path. The
+      // canonical lixrl.com URL is still valid, so creation must not fail.
+    }
+  }
   auditLog(user.id, 'url.create', 'url', shortCode, destinationUrl).catch(() => {});
 
   return NextResponse.json({
     short_url: `${env.BASE_URL}/${shortCode}`,
+    branded_url: brandedUrl,
     short_code: shortCode,
     original_url: destinationUrl,
     campaign: result?.campaign,

--- a/lib/subdomain-control.ts
+++ b/lib/subdomain-control.ts
@@ -1,0 +1,37 @@
+import type { SubdomainRecord } from './types';
+
+export type PublicSubdomain = Omit<SubdomainRecord, 'verification_token'>;
+
+export function publicSubdomain(record: SubdomainRecord): PublicSubdomain {
+  const { verification_token: _verificationToken, ...safe } = record;
+  return safe;
+}
+
+export async function bumpSubdomainRevision(
+  db: D1Database,
+  subdomainId: number,
+): Promise<number> {
+  const row = await db
+    .prepare(
+      `UPDATE subdomains
+       SET revision = revision + 1, updated_at = datetime('now')
+       WHERE id = ? RETURNING revision`,
+    )
+    .bind(subdomainId)
+    .first<{ revision: number }>();
+  return row?.revision ?? 1;
+}
+
+export async function bumpSubdomainRevisionsForUrl(
+  db: D1Database,
+  urlId: number,
+): Promise<void> {
+  await db
+    .prepare(
+      `UPDATE subdomains
+       SET revision = revision + 1, updated_at = datetime('now')
+       WHERE id IN (SELECT subdomain_id FROM subdomain_links WHERE url_id = ?)`,
+    )
+    .bind(urlId)
+    .run();
+}

--- a/lib/subdomains.ts
+++ b/lib/subdomains.ts
@@ -1,0 +1,58 @@
+import type { Tier } from './types';
+import { TIER_LIMITS } from './types';
+
+export const SUBDOMAIN_BASE = 'lixrl.com';
+export const VERIFICATION_TTL_SECONDS = 30 * 60;
+
+const LABEL_PATTERN = /^[a-z0-9](?:[a-z0-9-]{1,30}[a-z0-9])?$/;
+const RESERVED_LABELS = new Set([
+  'admin', 'api', 'app', 'assets', 'auth', 'blog', 'cdn', 'dashboard', 'docs',
+  'help', 'links', 'login', 'mail', 'pay', 'payouts', 'pricing', 'privacy',
+  'report', 'security', 'static', 'status', 'support', 'terms', 'www',
+]);
+
+export function normalizeSubdomainLabel(value: unknown): string {
+  return typeof value === 'string' ? value.trim().toLowerCase() : '';
+}
+
+export function validateSubdomainLabel(value: unknown): string | null {
+  const label = normalizeSubdomainLabel(value);
+  if (!label) return 'Subdomain is required';
+  if (label.length < 3 || label.length > 32) return 'Subdomain must be 3–32 characters';
+  if (label.includes('.') || !LABEL_PATTERN.test(label)) {
+    return 'Use lowercase letters, numbers, and interior hyphens only';
+  }
+  if (label.startsWith('xn--')) return 'Internationalized labels are not supported';
+  if (RESERVED_LABELS.has(label)) return 'This subdomain is reserved';
+  return null;
+}
+
+export function subdomainHostname(label: string): string {
+  return `${normalizeSubdomainLabel(label)}.${SUBDOMAIN_BASE}`;
+}
+
+export function subdomainEntitlement(tier: Tier): number {
+  return TIER_LIMITS[tier].brandedDomains;
+}
+
+export function hasSubdomainEntitlement(tier: Tier): boolean {
+  return subdomainEntitlement(tier) !== 0;
+}
+
+export function subdomainRedirectCacheKey(
+  subdomainId: number,
+  revision: number,
+  code: string,
+): string {
+  return `subdomain:${subdomainId}:r${revision}:url:${code.toLowerCase()}`;
+}
+
+export function generateVerificationToken(): string {
+  const bytes = new Uint8Array(24);
+  crypto.getRandomValues(bytes);
+  return Array.from(bytes, (byte) => byte.toString(16).padStart(2, '0')).join('');
+}
+
+export function verificationExpiry(): string {
+  return new Date(Date.now() + VERIFICATION_TTL_SECONDS * 1000).toISOString();
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -22,9 +22,8 @@ export interface TierLimits {
 }
 
 // -1 = unlimited. Only enforced capabilities may be shown by pricing and
-// subscription UIs. seats, brandedDomains, webhooks, and rateLimitPerMin are
-// reserved entitlement values for planned features and must not be marketed
-// until their corresponding product paths enforce them.
+// subscription UIs. seats, webhooks, and rateLimitPerMin remain reserved
+// entitlement values until their corresponding product paths enforce them.
 export const TIER_LIMITS: Record<Tier, TierLimits> = {
   free:       { maxUrls: 25,    maxApiKeys: 1,   maxClicksRetention: 7,   customCodes: false, analytics: false, expiringLinks: false, seats: 1,  brandedDomains: 0,  webhooks: false, rateLimitPerMin: 60,   qrPresets: 3,  qrLogo: false },
   pro:        { maxUrls: 1000,  maxApiKeys: 5,   maxClicksRetention: 30,  customCodes: true,  analytics: true,  expiringLinks: true,  seats: 1,  brandedDomains: 1,  webhooks: true,  rateLimitPerMin: 600,  qrPresets: -1, qrLogo: true },
@@ -106,6 +105,40 @@ export interface UrlRecord {
   expires_at: string | null;
   campaign?: string | null;
   tags?: string | null;
+}
+
+export type SubdomainStatus =
+  | 'pending'
+  | 'verified'
+  | 'active'
+  | 'failed'
+  | 'suspended'
+  | 'removed';
+
+export interface SubdomainRecord {
+  id: number;
+  user_id: number;
+  label: string;
+  hostname: string;
+  status: SubdomainStatus;
+  verification_token: string;
+  verification_expires_at: string;
+  verified_at: string | null;
+  activated_at: string | null;
+  removed_at: string | null;
+  last_error: string | null;
+  is_default: number;
+  revision: number;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface SubdomainLinkRecord {
+  id: number;
+  subdomain_id: number;
+  url_id: number;
+  short_code: string;
+  created_at: string;
 }
 
 export interface ClickRecord {

--- a/workers/migrations/0011_subdomain_routing.sql
+++ b/workers/migrations/0011_subdomain_routing.sql
@@ -1,0 +1,48 @@
+-- Paid, platform-owned one-level subdomains (for example acme.lixrl.com).
+-- Removed claims remain as history but no longer block a fresh, verified claim.
+CREATE TABLE subdomains (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  user_id INTEGER NOT NULL,
+  label TEXT NOT NULL COLLATE NOCASE,
+  hostname TEXT NOT NULL COLLATE NOCASE,
+  status TEXT NOT NULL DEFAULT 'pending'
+    CHECK(status IN ('pending', 'verified', 'active', 'failed', 'suspended', 'removed')),
+  verification_token TEXT NOT NULL UNIQUE,
+  verification_expires_at TEXT NOT NULL,
+  verified_at TEXT,
+  activated_at TEXT,
+  removed_at TEXT,
+  last_error TEXT,
+  is_default INTEGER NOT NULL DEFAULT 0 CHECK(is_default IN (0, 1)),
+  revision INTEGER NOT NULL DEFAULT 1,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX idx_subdomains_live_hostname
+  ON subdomains(hostname)
+  WHERE status != 'removed';
+CREATE UNIQUE INDEX idx_subdomains_user_default
+  ON subdomains(user_id)
+  WHERE is_default = 1 AND status = 'active';
+CREATE INDEX idx_subdomains_user_status ON subdomains(user_id, status);
+CREATE INDEX idx_subdomains_label_status ON subdomains(label, status);
+
+-- A link keeps its canonical lixrl.com short code. A domain mapping can use a
+-- different code, allowing the same branded code on separate subdomains.
+CREATE TABLE subdomain_links (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  subdomain_id INTEGER NOT NULL,
+  url_id INTEGER NOT NULL,
+  short_code TEXT NOT NULL COLLATE NOCASE,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  FOREIGN KEY (subdomain_id) REFERENCES subdomains(id) ON DELETE CASCADE,
+  FOREIGN KEY (url_id) REFERENCES urls(id) ON DELETE CASCADE,
+  UNIQUE(subdomain_id, short_code),
+  UNIQUE(subdomain_id, url_id)
+);
+
+CREATE INDEX idx_subdomain_links_lookup
+  ON subdomain_links(subdomain_id, short_code);
+CREATE INDEX idx_subdomain_links_url ON subdomain_links(url_id);

--- a/workers/subdomain-router.ts
+++ b/workers/subdomain-router.ts
@@ -1,0 +1,200 @@
+import { subdomainRedirectCacheKey, validateSubdomainLabel } from '../lib/subdomains';
+import { hashIp, hmacSha256Hex, isLikelyBot, parseUserAgent } from '../lib/utils';
+
+interface Env {
+  DB: D1Database;
+  KV: KVNamespace;
+  GUEST_FINGERPRINT_SECRET?: string;
+}
+
+interface DomainState {
+  id: number;
+  status: string;
+  revision: number;
+  verification_token: string;
+}
+
+interface RedirectRecord {
+  id: number;
+  original_url: string;
+  expires_at: string | null;
+}
+
+const NEGATIVE = '__missing__';
+const NEGATIVE_TTL = 60;
+const CACHE_TTL = 24 * 60 * 60;
+
+export default {
+  async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
+    const url = new URL(request.url);
+    const label = extractLabel(url.hostname);
+    if (!label || validateSubdomainLabel(label)) return notFound();
+
+    const domain = await env.DB
+      .prepare(
+        `SELECT s.id, s.status, s.revision, s.verification_token
+         FROM subdomains s
+         JOIN users u ON u.id = s.user_id
+         WHERE s.label = ? AND s.status != 'removed' AND u.is_active = 1
+         ORDER BY s.id DESC LIMIT 1`,
+      )
+      .bind(label)
+      .first<DomainState>();
+    if (!domain) return notFound();
+
+    if (url.pathname === '/.well-known/lixrl-domain-challenge') {
+      return verificationResponse(request, domain);
+    }
+    if (request.method !== 'GET' && request.method !== 'HEAD') {
+      return new Response('Method not allowed', { status: 405, headers: { Allow: 'GET, HEAD' } });
+    }
+    if (domain.status !== 'active') return notFound();
+
+    const entitlement = await env.DB
+      .prepare(
+        `SELECT 1 AS allowed
+         FROM subdomains s JOIN users u ON u.id = s.user_id
+         WHERE s.id = ? AND s.status = 'active'
+           AND u.tier IN ('pro', 'business', 'enterprise')
+           AND (u.tier_expires_at IS NULL OR u.tier_expires_at > datetime('now'))`,
+      )
+      .bind(domain.id)
+      .first<{ allowed: number }>();
+    if (!entitlement) return notFound();
+
+    const code = decodeURIComponent(url.pathname.replace(/^\/+/, '').split('/')[0] || '').toLowerCase();
+    if (!code || code.includes('/')) return notFound();
+    const cacheKey = subdomainRedirectCacheKey(domain.id, domain.revision, code);
+    const cached = await env.KV.get(cacheKey);
+    if (cached === NEGATIVE) return notFound();
+    if (cached) {
+      try {
+        const entry = JSON.parse(cached) as RedirectRecord;
+        if (entry.original_url && !isExpired(entry.expires_at)) {
+          ctx.waitUntil(trackClick(env, entry.id, request));
+          return redirect(entry.original_url);
+        }
+      } catch {
+        ctx.waitUntil(env.KV.delete(cacheKey));
+      }
+    }
+
+    const record = await env.DB
+      .prepare(
+        `SELECT u.id, u.original_url, u.expires_at
+         FROM subdomain_links dl
+         JOIN urls u ON u.id = dl.url_id
+         WHERE dl.subdomain_id = ? AND dl.short_code = ? AND u.is_active = 1
+           AND (u.expires_at IS NULL OR u.expires_at > datetime('now'))
+         LIMIT 1`,
+      )
+      .bind(domain.id, code)
+      .first<RedirectRecord>();
+    if (!record) {
+      ctx.waitUntil(env.KV.put(cacheKey, NEGATIVE, { expirationTtl: NEGATIVE_TTL }));
+      return notFound();
+    }
+
+    const ttl = record.expires_at
+      ? Math.floor((Date.parse(record.expires_at) - Date.now()) / 1000)
+      : CACHE_TTL;
+    if (ttl >= 60) {
+      ctx.waitUntil(env.KV.put(cacheKey, JSON.stringify(record), { expirationTtl: Math.min(ttl, CACHE_TTL) }));
+    }
+    ctx.waitUntil(trackClick(env, record.id, request));
+    return redirect(record.original_url);
+  },
+} satisfies ExportedHandler<Env>;
+
+function extractLabel(hostname: string): string | null {
+  const suffix = '.lixrl.com';
+  const normalized = hostname.toLowerCase().replace(/\.$/, '');
+  if (!normalized.endsWith(suffix)) return null;
+  const label = normalized.slice(0, -suffix.length);
+  return label && !label.includes('.') ? label : null;
+}
+
+function verificationResponse(request: Request, domain: DomainState): Response {
+  const supplied = request.headers.get('x-lixrl-verification-token') || '';
+  const allowedState = ['pending', 'verified', 'failed', 'suspended'].includes(domain.status);
+  if (!allowedState || !constantTimeEqual(supplied, domain.verification_token)) return notFound();
+  return Response.json(
+    { verified: true },
+    { headers: { 'Cache-Control': 'no-store', 'X-Robots-Tag': 'noindex' } },
+  );
+}
+
+function constantTimeEqual(left: string, right: string): boolean {
+  if (left.length !== right.length || left.length === 0) return false;
+  let result = 0;
+  for (let index = 0; index < left.length; index += 1) {
+    result |= left.charCodeAt(index) ^ right.charCodeAt(index);
+  }
+  return result === 0;
+}
+
+function isExpired(expiresAt: string | null): boolean {
+  return !!expiresAt && Date.parse(expiresAt) <= Date.now();
+}
+
+function redirect(destination: string): Response {
+  return new Response(null, {
+    status: 302,
+    headers: {
+      Location: destination,
+      'Cache-Control': 'private, no-cache, no-store',
+      'X-Robots-Tag': 'noindex',
+    },
+  });
+}
+
+function notFound(): Response {
+  return new Response('Short link not found', {
+    status: 404,
+    headers: { 'Cache-Control': 'private, no-store', 'X-Robots-Tag': 'noindex' },
+  });
+}
+
+async function trackClick(env: Env, urlId: number, request: Request): Promise<void> {
+  try {
+    const headers = request.headers;
+    const userAgent = headers.get('user-agent');
+    const ua = parseUserAgent(userAgent);
+    const cf = (request as Request & { cf?: Record<string, unknown> }).cf || {};
+    const rawIp = headers.get('cf-connecting-ip');
+    const secret = env.GUEST_FINGERPRINT_SECRET || '';
+    const ipHash = secret ? await hashIp(rawIp, secret) : null;
+    const day = new Date().toISOString().slice(0, 10);
+    const visitorHash = rawIp && secret
+      ? await hmacSha256Hex(`visitor-day-v1|${day}|${rawIp}|${userAgent || ''}`, secret)
+      : null;
+    const bot = isLikelyBot(userAgent);
+    let referer: string | null = null;
+    const rawReferer = headers.get('referer');
+    if (rawReferer) {
+      try { referer = new URL(rawReferer).origin; } catch { referer = rawReferer.slice(0, 200); }
+    }
+    await env.DB.batch([
+      env.DB.prepare('UPDATE urls SET clicks = clicks + ? WHERE id = ?').bind(bot ? 0 : 1, urlId),
+      env.DB.prepare(
+        `INSERT INTO clicks
+          (url_id, country, city, region, device, browser, os, referer, ip_hash, visitor_hash, is_bot)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      ).bind(
+        urlId,
+        (cf.country as string | undefined) || headers.get('cf-ipcountry'),
+        (cf.city as string | undefined) || null,
+        (cf.region as string | undefined) || null,
+        ua.device,
+        ua.browser,
+        ua.os,
+        referer,
+        ipHash,
+        visitorHash,
+        bot ? 1 : 0,
+      ),
+    ]);
+  } catch {
+    // Analytics must never block or fail a redirect.
+  }
+}

--- a/wrangler.subdomains.toml
+++ b/wrangler.subdomains.toml
@@ -1,0 +1,17 @@
+name = "lixrl-subdomain-router"
+main = "workers/subdomain-router.ts"
+compatibility_date = "2025-06-20"
+
+routes = [
+  { pattern = "*.lixrl.com/*", zone_name = "lixrl.com" }
+]
+
+[[d1_databases]]
+binding = "DB"
+database_name = "elixpourl"
+database_id = "50a21a28-62de-4787-81ad-3740e05ca2b5"
+migrations_dir = "workers/migrations"
+
+[[kv_namespaces]]
+binding = "KV"
+id = "e86dbfebc3114c748cc8557edc95948a"


### PR DESCRIPTION
## What this does
Adds paid, single-level `name.lixrl.com` routing while keeping canonical `lixrl.com/code` fallbacks.

## Architecture
- Pages remains the authenticated control plane.
- A dedicated Worker serves `*.lixrl.com/*` because Pages does not support wildcard custom domains.
- D1 owns labels, lifecycle state, mappings, entitlements, and route revisions.
- KV keys include domain ID + revision + code; D1 validates active ownership and paid status before cache use.

## Product
- Pro: 1 subdomain; Business: 3.
- Claim, TLS/router verification, default selection, mapping/unmapping, suspension, removal, and fresh reclaim.
- Same branded code can exist on separate subdomains.
- Dashboard, pricing, terms, privacy, and integration docs updated.

## Operations
Production deploy now ships Pages plus `wrangler.subdomains.toml`. A proxied wildcard DNS record and a Worker `GUEST_FINGERPRINT_SECRET` are required before activation.

## Verification
- Migrations 0001–0011 apply to fresh SQLite; integrity check is `ok`.
- All new API routes export edge runtime.
- `bash -n deploy.sh` and diff checks pass.
- Pages/Worker CI pending.

Fixes #24