### PR TITLE
[ELIXPO] Fix production Pages config discovery

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -145,10 +145,15 @@ do_deploy() {
     dim "Preview deploy — production URL stays on whatever's deployed to main."
   fi
   load_cloudflare_auth
-  npx wrangler pages deploy "$OUTDIR" \
-    --config="$WRANGLER_CONFIG" \
-    --project-name="$PROJECT" \
-    --branch="$BRANCH"
+  # Pages only accepts the default wrangler.toml path. Run from the project
+  # root so Wrangler discovers that config implicitly; an explicit --config
+  # fails even when it resolves to this same file.
+  (
+    cd "$SCRIPT_DIR"
+    npx wrangler pages deploy "$OUTDIR" \
+      --project-name="$PROJECT" \
+      --branch="$BRANCH"
+  )
   if [ "$BRANCH" = "main" ]; then
     log "Deploying the ${BOLD}*.lixrl.com${RESET} redirect Worker..."
     npx wrangler deploy --config="$SUBDOMAIN_WRANGLER_CONFIG"


### PR DESCRIPTION
## What this does
Fixes the production deploy command so Cloudflare Pages discovers the repository `wrangler.toml` from the project root. The dedicated subdomain Worker continues to use `wrangler.subdomains.toml` explicitly.

## Why
Run `32932106878` applied migration 0011 but failed before Pages and Worker deployment because Pages rejects an explicit custom Wrangler config path.

## Changes
- `deploy.sh`: run `wrangler pages deploy` from the project root.
- Remove the unsupported Pages `--config` argument.
- Preserve the explicit Worker config used by `lixrl-subdomain-router`.

## Verification
- `bash -n deploy.sh` passed.
- `git diff --check` passed.
- Build intentionally deferred to CI.

---
Fixes #27