### PR TITLE
[ELIXPO] Put pricing offers above the fold

### DIFF
--- a/app/pricing/page.tsx
+++ b/app/pricing/page.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import Link from 'next/link';
 import { type ReactNode, useCallback, useEffect, useState } from 'react';
 import Footer from '../components/Footer';
 import Navbar from '../components/Navbar';
@@ -14,12 +13,12 @@ import {
   TIER_PRICING,
 } from '@/lib/types';
 
-const ACCENT = '#e53935';
+const ACCENT = '#9b7bf7';
 
 const PLAN_GUIDANCE: Record<SellableTier, string> = {
-  free: 'Learn the workflow and keep a small personal link set.',
-  pro: 'Publish regularly with branded slugs and useful analytics.',
-  business: 'Run higher-volume campaigns with a full year of history.',
+  free: 'For personal links and trying Lixrl.',
+  pro: 'For creators and products publishing regularly.',
+  business: 'For teams managing campaigns at scale.',
 };
 
 const COMPARISON_ROWS: { label: string; values: Record<SellableTier, string> }[] = [
@@ -42,14 +41,16 @@ function retentionLabel(days: number): string {
 function featuresFor(tier: SellableTier): string[] {
   const l = TIER_LIMITS[tier];
   const out = [
-    `${l.maxUrls.toLocaleString()} short links`,
+    tier === 'free'
+      ? `2 new links/day · ${l.maxUrls.toLocaleString()} stored`
+      : `${l.maxUrls.toLocaleString()} short links`,
     retentionLabel(l.maxClicksRetention),
     `${l.maxApiKeys} API key${l.maxApiKeys === 1 ? '' : 's'}`,
   ];
   out.push(l.customCodes ? 'Custom slugs' : 'Auto-generated slugs');
+  if (l.brandedDomains > 0) out.push(`${l.brandedDomains} branded lixrl.com subdomain${l.brandedDomains === 1 ? '' : 's'}`);
   out.push(l.analytics ? 'Geo / device analytics + CSV' : 'Click totals');
   if (l.expiringLinks) out.push('Expiring links');
-  if (l.brandedDomains > 0) out.push(`${l.brandedDomains} branded lixrl.com subdomain${l.brandedDomains === 1 ? '' : 's'}`);
   if (l.qrLogo) out.push('Custom QR logos and styles');
   return out;
 }
@@ -137,41 +138,24 @@ export default function PricingPage() {
         <Navbar />
       </div>
 
-      <main className="relative z-10 flex-1 w-full max-w-5xl mx-auto px-4 md:px-6 pt-10 md:pt-16 pb-16">
-        <section className="text-center max-w-[780px] mx-auto flex flex-col items-center gap-5">
-          <span className="rounded-full border border-[#f0c8c6] bg-[#fff6f5] px-3 py-1 text-[11px] font-bold uppercase tracking-[0.12em] text-[#c62828]">
-            Clear limits · no hidden feature promises
-          </span>
+      <main className="relative z-10 flex-1 w-full max-w-6xl mx-auto px-4 md:px-6 pt-6 md:pt-8 pb-16">
+        <section className="text-center max-w-[760px] mx-auto flex flex-col items-center gap-3">
           <h1
-            className="text-[2.2rem] md:text-[3.2rem] font-extrabold leading-[1.08] tracking-tight"
+            className="text-[2.15rem] md:text-[2.75rem] font-extrabold leading-[1.08] tracking-tight"
             style={{
               background: 'linear-gradient(180deg, #111111 0%, #555555 100%)',
               WebkitBackgroundClip: 'text',
               WebkitTextFillColor: 'transparent',
             }}
           >
-            Pick the right plan <span style={{ color: ACCENT }}>at a glance.</span>
+            Simple pricing. <span style={{ color: ACCENT, WebkitTextFillColor: ACCENT }}>Start free.</span>
           </h1>
-          <p className="text-base md:text-[1.1rem] text-[#555] max-w-[650px] leading-relaxed">
-            Free is enough to try the full workflow. Choose Pro for regular publishing,
-            or Business when volume and a year of analytics matter.
+          <p className="text-sm md:text-base text-[#666] max-w-[580px] leading-relaxed">
+            Choose a plan now. Compare every limit below when you need the details.
           </p>
 
-          <div className="grid w-full grid-cols-1 gap-2 text-left sm:grid-cols-3">
-            {[
-              ['Guest', '1 link · expires in 24 hours'],
-              ['Free account', '2 new links/day · 25 stored'],
-              ['Every paid plan', 'Cancel renewal anytime'],
-            ].map(([label, detail]) => (
-              <div key={label} className="rounded-xl border border-[#e8e8e8] bg-[#fafafa] px-4 py-3">
-                <div className="text-xs font-bold text-[#111]">{label}</div>
-                <div className="mt-1 text-xs text-[#666]">{detail}</div>
-              </div>
-            ))}
-          </div>
-
           {/* Toggles: currency + billing interval */}
-          <div className="flex flex-wrap items-center justify-center gap-3 pt-1">
+          <div className="flex flex-wrap items-center justify-center gap-3 pt-2">
             <Toggle
               options={[
                 { value: 'INR', label: '₹ INR' },
@@ -191,37 +175,25 @@ export default function PricingPage() {
               />
               <span
                 className="text-[0.7rem] font-bold px-2 py-1 rounded-full whitespace-nowrap"
-                style={{ background: 'rgba(52,211,153,0.14)', color: '#6ee7b7', border: '1px solid rgba(52,211,153,0.3)' }}
+                style={{ background: 'rgba(155,123,247,0.12)', color: '#6f52d9', border: '1px solid rgba(155,123,247,0.28)' }}
               >
                 2 months free
               </span>
             </div>
-          </div>
-
-          {/* Trust strip — lowers purchase anxiety */}
-          <div className="flex flex-wrap items-center justify-center gap-x-5 gap-y-2 text-[0.78rem] text-white/55 pt-1">
-            {['No card on Free', 'Hosted checkout', 'Edge redirects on every plan'].map((t) => (
-              <span key={t} className="inline-flex items-center gap-1.5">
-                <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="#6ee7b7" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
-                  <polyline points="20 6 9 17 4 12" />
-                </svg>
-                {t}
-              </span>
-            ))}
           </div>
         </section>
 
         {error && (
           <div
             className="mt-6 mx-auto max-w-md text-center text-sm rounded-xl px-4 py-3"
-            style={{ background: 'rgba(248,113,113,0.12)', border: '1px solid rgba(248,113,113,0.3)', color: '#fca5a5' }}
+            style={{ background: 'rgba(248,113,113,0.10)', border: '1px solid rgba(185,28,28,0.22)', color: '#b42318' }}
           >
             {error}
           </div>
         )}
 
-        {/* Tier cards */}
-        <section className="mt-10 md:mt-12 grid grid-cols-1 md:grid-cols-3 gap-5">
+        {/* One offer panel keeps prices and actions comparable without scrolling. */}
+        <section className="mt-6 grid grid-cols-1 overflow-hidden rounded-[22px] border border-[#ded8f2] bg-white shadow-[0_20px_60px_rgba(74,52,130,0.10)] md:grid-cols-3">
           {SELLABLE_TIER_ORDER.map((tier) => {
             const p = TIER_PRICING[tier];
             const amount = p.price[currency][interval];
@@ -230,34 +202,29 @@ export default function PricingPage() {
             return (
               <div
                 key={tier}
-                className="p-6 rounded-[18px] relative flex flex-col transition-opacity"
+                className="relative flex flex-col border-t border-[#ece8f7] p-5 first:border-t-0 md:min-h-[430px] md:border-l md:border-t-0 md:first:border-l-0 lg:p-6"
                 style={{
                   // Current plan is greyed/dimmed — it's not an upgrade target.
                   background: isCurrent
                     ? 'linear-gradient(135deg, rgba(0,0,0,0.04) 0%, rgba(250,250,250,0.9) 100%)'
                     : isPopular
-                      ? 'linear-gradient(135deg, rgba(229,57,53,0.16) 0%, rgba(95,182,255,0.05) 100%)'
+                      ? 'linear-gradient(145deg, rgba(155,123,247,0.16) 0%, rgba(124,92,255,0.04) 100%)'
                       : 'linear-gradient(135deg, rgba(255,255,255,0.96) 0%, rgba(250,250,250,0.92) 100%)',
-                  border: isCurrent
-                    ? '1px solid rgba(0,0,0,0.08)'
-                    : isPopular
-                      ? '1px solid rgba(229,57,53,0.45)'
-                      : '1px solid rgba(0,0,0,0.10)',
                   backdropFilter: 'blur(20px)',
                   opacity: isCurrent ? 0.6 : 1,
                 }}
               >
                 {isCurrent ? (
                   <span
-                    className="absolute -top-3 left-1/2 -translate-x-1/2 text-[10px] font-bold tracking-wider uppercase px-3 py-1 rounded-full"
+                    className="absolute right-4 top-4 rounded-full px-3 py-1 text-[10px] font-bold uppercase tracking-wider"
                     style={{ background: 'rgba(0,0,0,0.12)', color: 'rgba(0,0,0,0.8)', border: '1px solid rgba(0,0,0,0.2)' }}
                   >
                     Current plan
                   </span>
                 ) : isPopular ? (
                   <span
-                    className="absolute -top-3 left-1/2 -translate-x-1/2 text-[10px] font-bold tracking-wider uppercase px-3 py-1 rounded-full text-white"
-                    style={{ background: 'linear-gradient(135deg, #e53935 0%, #c62828 100%)' }}
+                    className="absolute right-4 top-4 rounded-full px-3 py-1 text-[10px] font-bold uppercase tracking-wider text-white"
+                    style={{ background: 'linear-gradient(135deg, #9b7bf7 0%, #7c5cff 100%)' }}
                   >
                     Most popular
                   </span>
@@ -265,7 +232,7 @@ export default function PricingPage() {
 
                 <h3 className="text-[1.15rem] font-bold text-[#111]">{p.name}</h3>
                 <p className="text-[0.85rem] text-[#666] mt-1 min-h-[2.4em]">{p.tagline}</p>
-                <p className="mb-4 mt-2 min-h-[3em] text-[0.78rem] leading-5 text-[#777]">{PLAN_GUIDANCE[tier]}</p>
+                <p className="mb-3 mt-2 min-h-[2.5em] text-[0.78rem] leading-5 text-[#777]">{PLAN_GUIDANCE[tier]}</p>
 
                 <div className="flex items-baseline gap-1 mb-1">
                   <span className="text-[2.1rem] font-extrabold text-[#111]">
@@ -287,7 +254,7 @@ export default function PricingPage() {
                         : 'Free forever'}
                   </span>
                   {amount > 0 && interval === 'annual' && (
-                    <span className="font-semibold" style={{ color: '#6ee7b7' }}>
+                    <span className="font-semibold text-[#278560]">
                       save {CURRENCY_SYMBOL[currency]}
                       {(p.price[currency].monthly * 12 - amount).toLocaleString()}
                     </span>
@@ -305,8 +272,8 @@ export default function PricingPage() {
                   currentTier={me.currentTier}
                 />
 
-                <ul className="space-y-2 list-none p-0 mt-6">
-                  {featuresFor(tier).map((f) => (
+                <ul className="space-y-2 list-none p-0 mt-5">
+                  {featuresFor(tier).slice(0, 5).map((f) => (
                     <li key={f} className="text-[0.85rem] text-[#555] flex items-start gap-2">
                       <span className="mt-1.5 flex-shrink-0 w-1.5 h-1.5 rounded-full" style={{ background: ACCENT }} />
                       {f}
@@ -318,14 +285,14 @@ export default function PricingPage() {
           })}
         </section>
 
-        <section className="mt-16" aria-labelledby="compare-plans">
+        <section className="mt-14" aria-labelledby="compare-plans">
           <div className="max-w-2xl">
-            <p className="text-[11px] font-bold uppercase tracking-[0.12em] text-[#c62828]">Exact plan limits</p>
+            <p className="text-[11px] font-bold uppercase tracking-[0.12em] text-[#7052d6]">Plan details</p>
             <h2 id="compare-plans" className="mt-2 text-2xl font-extrabold tracking-tight text-[#111] md:text-3xl">
-              Compare what changes when you upgrade
+              Compare every limit
             </h2>
             <p className="mt-3 text-sm leading-6 text-[#666]">
-              Every item below is available in the product today and enforced by the API.
+              The details are here when you need them. These limits match what the product enforces.
             </p>
           </div>
           <div className="mt-6 overflow-x-auto rounded-2xl border border-[#e5e5e5]">
@@ -352,75 +319,9 @@ export default function PricingPage() {
           </div>
         </section>
 
-        {/* Enterprise — non-priced 16:9 card to balance the layout */}
-        <section className="mt-16">
-          <div
-            className="relative mx-auto flex min-h-[320px] w-full max-w-3xl items-center justify-center overflow-hidden rounded-[22px] px-6 py-10 text-center"
-            style={{
-              background:
-                'radial-gradient(120% 120% at 50% 0%, rgba(229,57,53,0.18) 0%, rgba(95,182,255,0.06) 40%, rgba(0,0,0,0.03) 100%)',
-              border: '1px solid rgba(229,57,53,0.28)',
-            }}
-          >
-            {/* soft glow accent */}
-            <div
-              className="pointer-events-none absolute -top-24 left-1/2 -translate-x-1/2 w-[420px] h-[420px] rounded-full"
-              style={{ background: 'radial-gradient(circle, rgba(229,57,53,0.22) 0%, transparent 65%)' }}
-            />
-            <div className="relative z-10 flex flex-col items-center gap-4 max-w-[560px]">
-              <span
-                className="text-[10px] font-bold tracking-[0.18em] uppercase px-3 py-1 rounded-full"
-                style={{ background: 'rgba(229,57,53,0.16)', color: '#c62828', border: '1px solid rgba(229,57,53,0.35)' }}
-              >
-                Enterprise
-              </span>
-              <h3
-                className="text-[1.5rem] md:text-[1.9rem] font-extrabold leading-tight"
-                style={{
-                  background: 'linear-gradient(180deg, #111111 0%, #555555 100%)',
-                  WebkitBackgroundClip: 'text',
-                  WebkitTextFillColor: 'transparent',
-                }}
-              >
-                Built around your organization
-              </h3>
-
-              {/* Short perks */}
-              <div className="flex flex-wrap items-center justify-center gap-x-4 gap-y-2">
-                {[
-                  'Custom link limits',
-                  'Up to 2 years of analytics',
-                  'Up to 100 API keys',
-                  'Custom billing review',
-                  'Priority onboarding',
-                ].map((perk) => (
-                  <span key={perk} className="inline-flex items-center gap-1.5 text-[0.82rem] text-white/75">
-                    <span className="w-1.5 h-1.5 rounded-full shrink-0" style={{ background: ACCENT }} />
-                    {perk}
-                  </span>
-                ))}
-              </div>
-
-              <div className="flex flex-col sm:flex-row items-center gap-3 mt-1">
-                <a
-                  href="mailto:hello@elixpo.com?subject=ElixpoURL%20Enterprise"
-                  className="inline-flex items-center justify-center gap-2 px-6 py-2.5 rounded-[12px] font-semibold text-sm text-white no-underline transition-all"
-                  style={{
-                    background: 'linear-gradient(135deg, #e53935 0%, #c62828 100%)',
-                    boxShadow: '0 8px 24px rgba(229,57,53,0.35)',
-                  }}
-                >
-                  Contact team
-                </a>
-                <EmailChip />
-              </div>
-            </div>
-          </div>
-        </section>
-
         <section className="mx-auto mt-16 max-w-3xl" aria-labelledby="pricing-faq">
           <div className="text-center">
-            <p className="text-[11px] font-bold uppercase tracking-[0.12em] text-[#c62828]">Before you choose</p>
+            <p className="text-[11px] font-bold uppercase tracking-[0.12em] text-[#7052d6]">Before you choose</p>
             <h2 id="pricing-faq" className="mt-2 text-2xl font-extrabold tracking-tight text-[#111] md:text-3xl">Pricing questions, answered</h2>
           </div>
           <div className="mt-7 divide-y divide-[#e8e8e8] rounded-2xl border border-[#e5e5e5] px-5 md:px-7">
@@ -488,7 +389,7 @@ function Toggle({
           className="px-3.5 py-1.5 rounded-[9px] text-[0.82rem] font-semibold transition-all cursor-pointer border-none"
           style={
             value === o.value
-              ? { background: 'linear-gradient(135deg, #e53935 0%, #c62828 100%)', color: '#fff' }
+              ? { background: 'linear-gradient(135deg, #9b7bf7 0%, #7c5cff 100%)', color: '#fff' }
               : { background: 'transparent', color: 'rgba(0,0,0,0.6)' }
           }
         >
@@ -557,9 +458,9 @@ function CtaButton({
         background: isCurrentPlanCta
           ? 'rgba(0,0,0,0.06)'
           : filled
-            ? 'linear-gradient(135deg, #e53935 0%, #c62828 100%)'
+            ? 'linear-gradient(135deg, #9b7bf7 0%, #7c5cff 100%)'
             : 'transparent',
-        boxShadow: filled && !disabled ? '0 6px 18px rgba(229,57,53,0.32)' : 'none',
+        boxShadow: filled && !disabled ? '0 6px 18px rgba(124,92,255,0.28)' : 'none',
         border: isCurrentPlanCta
           ? '1px solid rgba(0,0,0,0.1)'
           : filled
@@ -574,77 +475,6 @@ function CtaButton({
         />
       )}
       {label}
-    </button>
-  );
-}
-
-function EmailChip() {
-  const [copied, setCopied] = useState(false);
-  const email = 'hello@elixpo.com';
-
-  const handleCopyEmail = async () => {
-    try {
-      await navigator.clipboard.writeText(email);
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2200);
-    } catch {
-      const ta = document.createElement('textarea');
-      ta.value = email;
-      document.body.appendChild(ta);
-      ta.select();
-      try {
-        document.execCommand('copy');
-        setCopied(true);
-        setTimeout(() => setCopied(false), 2200);
-      } catch {
-        window.location.href = `mailto:${email}`;
-      }
-      document.body.removeChild(ta);
-    }
-  };
-
-  return (
-    <button
-      type="button"
-      onClick={handleCopyEmail}
-      className="inline-flex items-center gap-2 px-4 py-2.5 rounded-[12px] text-sm transition-all"
-      style={{
-        border: '1px solid rgba(0, 0, 0, 0.14)',
-        background: '#fff',
-        color: '#555',
-        fontFamily: 'var(--font-geist-mono), monospace',
-        cursor: 'pointer',
-      }}
-      onMouseEnter={(e) => {
-        e.currentTarget.style.color = '#111';
-        e.currentTarget.style.borderColor = 'rgba(229, 57, 53, 0.5)';
-        e.currentTarget.style.background = 'rgba(229, 57, 53, 0.08)';
-      }}
-      onMouseLeave={(e) => {
-        e.currentTarget.style.color = '#555';
-        e.currentTarget.style.borderColor = 'rgba(0, 0, 0, 0.14)';
-        e.currentTarget.style.background = '#fff';
-      }}
-      title={copied ? 'Copied!' : 'Click to copy'}
-    >
-      <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-        <path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z" />
-        <polyline points="22,6 12,13 2,6" />
-      </svg>
-      <span>{email}</span>
-      {copied ? (
-        <span className="flex items-center gap-1 text-xs font-semibold text-[#86efac] transition-all animate-pulse">
-          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="#86efac" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round">
-            <polyline points="20,6 9,17 4,12" />
-          </svg>
-          <span>Copied!</span>
-        </span>
-      ) : (
-        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" opacity="0.4">
-          <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
-          <path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1" />
-        </svg>
-      )}
     </button>
   );
 }


### PR DESCRIPTION
## What this does
Makes Free, Pro, and Business immediately comparable in one unified pricing panel. Removes the Enterprise offer and moves the detailed limits below the main buying decision.

## Changes
- Compress the heading and controls so pricing appears without introductory scrolling.
- Present all three offers side by side inside one responsive panel.
- Surface daily Free limits and paid branded subdomains in the visible highlights.
- Move full feature details below the offer panel.
- Replace the legacy red accent with the Lixrl purple system.
- Remove the Enterprise card and unused contact UI.

## Verification
- `git diff --check` passed.
- Build and npm checks intentionally deferred per request.

---
Fixes #29