### PR TITLE
[ELIXPO] Add About page and improve public SEO

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -82,7 +82,7 @@ export default function AboutPage() {
           </div>
           <div className="lg:pb-1">
             <p className="text-base leading-7 text-[#5f5f66] md:text-lg">
-              Lixrl helps people turn unwieldy addresses into short, useful links—and then understand how those links perform.
+              Lixrl is a URL shortener that turns unwieldy addresses into useful links—and then helps people understand how those links perform.
             </p>
             <div className="mt-7 flex flex-wrap gap-3">
               <Link href="/" className="rounded-full bg-gradient-to-r from-[#9b7bf7] to-[#7c5cff] px-5 py-2.5 text-sm font-semibold text-white no-underline shadow-[0_8px_24px_rgba(124,92,255,0.24)]">

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -75,7 +75,7 @@ export default function AboutPage() {
       <main>
         <section className="mx-auto grid w-full max-w-6xl gap-10 px-4 pb-16 pt-14 md:px-6 md:pb-24 md:pt-20 lg:grid-cols-[1.15fr_0.85fr] lg:items-end">
           <div>
-            <p className="mb-5 text-xs font-bold uppercase tracking-[0.16em] text-[#7052d6]">About Lixrl</p>
+            <p className="mb-5 text-xs font-bold uppercase tracking-[0.16em] text-[#c62828]">About Lixrl</p>
             <h1 className="max-w-3xl text-[2.75rem] font-extrabold leading-[1.02] tracking-[-0.045em] text-[#111] sm:text-6xl">
               One link. A clearer way to share.
             </h1>
@@ -85,26 +85,26 @@ export default function AboutPage() {
               Lixrl is a URL shortener that turns unwieldy addresses into useful links—and then helps people understand how those links perform.
             </p>
             <div className="mt-7 flex flex-wrap gap-3">
-              <Link href="/" className="rounded-full bg-gradient-to-r from-[#9b7bf7] to-[#7c5cff] px-5 py-2.5 text-sm font-semibold text-white no-underline shadow-[0_8px_24px_rgba(124,92,255,0.24)]">
+              <Link href="/" className="rounded-full bg-gradient-to-r from-[#e53935] to-[#c62828] px-5 py-2.5 text-sm font-semibold text-white no-underline shadow-[0_8px_24px_rgba(229,57,53,0.22)]">
                 Shorten a link
               </Link>
-              <Link href="/pricing" className="rounded-full border border-[#d8d3e6] bg-white px-5 py-2.5 text-sm font-semibold text-[#352f42] no-underline transition-colors hover:border-[#9b7bf7]">
+              <Link href="/pricing" className="rounded-full border border-[#dddddd] bg-white px-5 py-2.5 text-sm font-semibold text-[#352f42] no-underline transition-colors hover:border-[#e53935]">
                 Compare plans
               </Link>
             </div>
           </div>
         </section>
 
-        <section className="border-y border-[#ebe8f1] bg-[#faf9fc]" aria-labelledby="what-we-do">
+        <section className="border-y border-[#e8e8e8] bg-[#fafafa]" aria-labelledby="what-we-do">
           <div className="mx-auto w-full max-w-6xl px-4 py-16 md:px-6 md:py-20">
             <div className="max-w-2xl">
-              <p className="text-xs font-bold uppercase tracking-[0.16em] text-[#7052d6]">What we do</p>
+              <p className="text-xs font-bold uppercase tracking-[0.16em] text-[#c62828]">What we do</p>
               <h2 id="what-we-do" className="mt-3 text-3xl font-extrabold tracking-tight md:text-4xl">A complete home for every short link</h2>
             </div>
-            <div className="mt-10 grid gap-px overflow-hidden rounded-2xl border border-[#e4dfed] bg-[#e4dfed] md:grid-cols-2">
+            <div className="mt-10 grid gap-px overflow-hidden rounded-2xl border border-[#e5e5e5] bg-[#e5e5e5] md:grid-cols-2">
               {outcomes.map((item) => (
                 <article key={item.number} className="bg-white p-6 md:p-8">
-                  <span className="font-mono text-xs font-semibold text-[#8a70de]">{item.number}</span>
+                  <span className="font-mono text-xs font-semibold text-[#c62828]">{item.number}</span>
                   <h3 className="mt-5 text-xl font-bold tracking-tight">{item.title}</h3>
                   <p className="mt-3 max-w-lg text-sm leading-6 text-[#66616d]">{item.body}</p>
                 </article>
@@ -116,7 +116,7 @@ export default function AboutPage() {
         <section className="mx-auto w-full max-w-6xl px-4 py-16 md:px-6 md:py-24" aria-labelledby="why-lixrl">
           <div className="grid gap-10 lg:grid-cols-[0.7fr_1.3fr]">
             <div>
-              <p className="text-xs font-bold uppercase tracking-[0.16em] text-[#7052d6]">Why Lixrl</p>
+              <p className="text-xs font-bold uppercase tracking-[0.16em] text-[#c62828]">Why Lixrl</p>
               <h2 id="why-lixrl" className="mt-3 text-3xl font-extrabold tracking-tight md:text-4xl">Less friction at every step</h2>
               <p className="mt-4 max-w-md text-sm leading-6 text-[#66616d]">
                 The product is designed to get out of the way: start quickly, see what matters, and add more control only when you need it.
@@ -124,7 +124,7 @@ export default function AboutPage() {
             </div>
             <div className="grid gap-4 sm:grid-cols-2">
               {differences.map(([heading, body]) => (
-                <article key={heading} className="rounded-2xl border border-[#e5e1ed] bg-white p-5 shadow-[0_10px_35px_rgba(63,45,100,0.05)]">
+                <article key={heading} className="rounded-2xl border border-[#e5e5e5] bg-white p-5 shadow-[0_10px_35px_rgba(0,0,0,0.05)]">
                   <h3 className="font-bold text-[#24202b]">{heading}</h3>
                   <p className="mt-2 text-sm leading-6 text-[#6a6570]">{body}</p>
                 </article>
@@ -134,9 +134,9 @@ export default function AboutPage() {
         </section>
 
         <section className="px-4 pb-20 md:px-6 md:pb-28">
-          <div className="mx-auto flex w-full max-w-6xl flex-col items-start justify-between gap-7 overflow-hidden rounded-3xl border border-[#dcd4f2] bg-[linear-gradient(135deg,#f6f2ff_0%,#ffffff_70%)] p-7 md:flex-row md:items-center md:p-10">
+          <div className="mx-auto flex w-full max-w-6xl flex-col items-start justify-between gap-7 overflow-hidden rounded-3xl border border-[#f0c8c6] bg-[linear-gradient(135deg,#fff6f5_0%,#ffffff_70%)] p-7 md:flex-row md:items-center md:p-10">
             <div>
-              <p className="text-xs font-bold uppercase tracking-[0.16em] text-[#7052d6]">Ready when you are</p>
+              <p className="text-xs font-bold uppercase tracking-[0.16em] text-[#c62828]">Ready when you are</p>
               <h2 className="mt-3 text-2xl font-extrabold tracking-tight md:text-3xl">Make the next link easier to share.</h2>
               <p className="mt-2 text-sm text-[#66616d]">Try one guest link for 24 hours, or sign in to keep your work.</p>
             </div>

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,0 +1,158 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import Footer from '../components/Footer';
+import Navbar from '../components/Navbar';
+
+const title = 'About Lixrl';
+const description =
+  'Learn how Lixrl turns long addresses into fast, recognizable links with clear analytics, flexible controls, and branded subdomains.';
+
+export const metadata: Metadata = {
+  title,
+  description,
+  alternates: { canonical: '/about' },
+  openGraph: {
+    type: 'website',
+    url: '/about',
+    title: 'About Lixrl — A clearer way to share links',
+    description,
+    images: [{ url: '/og-image.png', width: 1822, height: 825, alt: 'Lixrl link shortener' }],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'About Lixrl — A clearer way to share links',
+    description,
+    images: ['/og-image.png'],
+  },
+};
+
+const outcomes = [
+  {
+    number: '01',
+    title: 'Make links easier to share',
+    body: 'Turn a long address into a short link that fits naturally in a post, message, profile, presentation, or QR code.',
+  },
+  {
+    number: '02',
+    title: 'Understand what happens next',
+    body: 'See when people open a link and learn which locations, devices, and sources are bringing attention to it.',
+  },
+  {
+    number: '03',
+    title: 'Keep every link under control',
+    body: 'Choose memorable names, set expiry dates, organize campaigns, and manage links from one focused dashboard.',
+  },
+  {
+    number: '04',
+    title: 'Give links a recognizable home',
+    body: 'Paid plans can use a single-level branded address such as yourbrand.lixrl.com, while Lixrl handles delivery and tracking.',
+  },
+];
+
+const differences = [
+  ['Useful before signup', 'Create one guest link in a single step. Make an account only when you want persistent links and a dashboard.'],
+  ['Fast wherever links travel', 'Requests are handled close to the person opening the link, keeping the redirect path short and responsive.'],
+  ['Clear limits', 'Plans explain exactly how many links, subdomains, and days of activity history are included.'],
+  ['Branding without extra setup', 'Claim a name under lixrl.com instead of configuring a separate domain and certificate.'],
+  ['Built around the link lifecycle', 'Creation, sharing, QR codes, expiry, activity, and editing belong to the same workflow.'],
+  ['Control stays visible', 'Existing links remain manageable from the dashboard, with straightforward states and actions.'],
+] as const;
+
+export default function AboutPage() {
+  const aboutSchema = {
+    '@context': 'https://schema.org',
+    '@type': 'AboutPage',
+    name: title,
+    url: 'https://lixrl.com/about',
+    description,
+    isPartOf: { '@type': 'WebSite', name: 'Lixrl', url: 'https://lixrl.com' },
+  };
+
+  return (
+    <div className="theme-light min-h-screen bg-white text-[#111]">
+      <Navbar />
+
+      <main>
+        <section className="mx-auto grid w-full max-w-6xl gap-10 px-4 pb-16 pt-14 md:px-6 md:pb-24 md:pt-20 lg:grid-cols-[1.15fr_0.85fr] lg:items-end">
+          <div>
+            <p className="mb-5 text-xs font-bold uppercase tracking-[0.16em] text-[#7052d6]">About Lixrl</p>
+            <h1 className="max-w-3xl text-[2.75rem] font-extrabold leading-[1.02] tracking-[-0.045em] text-[#111] sm:text-6xl">
+              One link. A clearer way to share.
+            </h1>
+          </div>
+          <div className="lg:pb-1">
+            <p className="text-base leading-7 text-[#5f5f66] md:text-lg">
+              Lixrl helps people turn unwieldy addresses into short, useful links—and then understand how those links perform.
+            </p>
+            <div className="mt-7 flex flex-wrap gap-3">
+              <Link href="/" className="rounded-full bg-gradient-to-r from-[#9b7bf7] to-[#7c5cff] px-5 py-2.5 text-sm font-semibold text-white no-underline shadow-[0_8px_24px_rgba(124,92,255,0.24)]">
+                Shorten a link
+              </Link>
+              <Link href="/pricing" className="rounded-full border border-[#d8d3e6] bg-white px-5 py-2.5 text-sm font-semibold text-[#352f42] no-underline transition-colors hover:border-[#9b7bf7]">
+                Compare plans
+              </Link>
+            </div>
+          </div>
+        </section>
+
+        <section className="border-y border-[#ebe8f1] bg-[#faf9fc]" aria-labelledby="what-we-do">
+          <div className="mx-auto w-full max-w-6xl px-4 py-16 md:px-6 md:py-20">
+            <div className="max-w-2xl">
+              <p className="text-xs font-bold uppercase tracking-[0.16em] text-[#7052d6]">What we do</p>
+              <h2 id="what-we-do" className="mt-3 text-3xl font-extrabold tracking-tight md:text-4xl">A complete home for every short link</h2>
+            </div>
+            <div className="mt-10 grid gap-px overflow-hidden rounded-2xl border border-[#e4dfed] bg-[#e4dfed] md:grid-cols-2">
+              {outcomes.map((item) => (
+                <article key={item.number} className="bg-white p-6 md:p-8">
+                  <span className="font-mono text-xs font-semibold text-[#8a70de]">{item.number}</span>
+                  <h3 className="mt-5 text-xl font-bold tracking-tight">{item.title}</h3>
+                  <p className="mt-3 max-w-lg text-sm leading-6 text-[#66616d]">{item.body}</p>
+                </article>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section className="mx-auto w-full max-w-6xl px-4 py-16 md:px-6 md:py-24" aria-labelledby="why-lixrl">
+          <div className="grid gap-10 lg:grid-cols-[0.7fr_1.3fr]">
+            <div>
+              <p className="text-xs font-bold uppercase tracking-[0.16em] text-[#7052d6]">Why Lixrl</p>
+              <h2 id="why-lixrl" className="mt-3 text-3xl font-extrabold tracking-tight md:text-4xl">Less friction at every step</h2>
+              <p className="mt-4 max-w-md text-sm leading-6 text-[#66616d]">
+                The product is designed to get out of the way: start quickly, see what matters, and add more control only when you need it.
+              </p>
+            </div>
+            <div className="grid gap-4 sm:grid-cols-2">
+              {differences.map(([heading, body]) => (
+                <article key={heading} className="rounded-2xl border border-[#e5e1ed] bg-white p-5 shadow-[0_10px_35px_rgba(63,45,100,0.05)]">
+                  <h3 className="font-bold text-[#24202b]">{heading}</h3>
+                  <p className="mt-2 text-sm leading-6 text-[#6a6570]">{body}</p>
+                </article>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section className="px-4 pb-20 md:px-6 md:pb-28">
+          <div className="mx-auto flex w-full max-w-6xl flex-col items-start justify-between gap-7 overflow-hidden rounded-3xl border border-[#dcd4f2] bg-[linear-gradient(135deg,#f6f2ff_0%,#ffffff_70%)] p-7 md:flex-row md:items-center md:p-10">
+            <div>
+              <p className="text-xs font-bold uppercase tracking-[0.16em] text-[#7052d6]">Ready when you are</p>
+              <h2 className="mt-3 text-2xl font-extrabold tracking-tight md:text-3xl">Make the next link easier to share.</h2>
+              <p className="mt-2 text-sm text-[#66616d]">Try one guest link for 24 hours, or sign in to keep your work.</p>
+            </div>
+            <Link href="/" className="shrink-0 rounded-full bg-[#111] px-6 py-3 text-sm font-semibold text-white no-underline transition-transform hover:-translate-y-0.5">
+              Create a short link
+            </Link>
+          </div>
+        </section>
+
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(aboutSchema) }}
+        />
+      </main>
+
+      <Footer />
+    </div>
+  );
+}

--- a/app/components/Footer.tsx
+++ b/app/components/Footer.tsx
@@ -3,7 +3,7 @@
 import Link from 'next/link';
 import { useState } from 'react';
 
-const ACCENT = '#e53935';
+const ACCENT = '#9b7bf7';
 const EMAIL = 'hello@elixpo.com';
 const REPO_URL = 'https://github.com/elixpo/elixpourl';
 const LICENSE_URL = `${REPO_URL}/blob/main/LICENSE`;
@@ -18,6 +18,7 @@ interface FooterLink {
 
 const PRODUCT_LINKS: FooterLink[] = [
   { label: 'Sign in with Elixpo', href: '/api/auth/login' },
+  { label: 'About', href: '/about' },
   { label: 'Pricing', href: '/pricing' },
   { label: 'Docs', href: '/docs' },
   { label: 'Dashboard', href: '/dashboard' },
@@ -161,8 +162,8 @@ export default function Footer() {
               }}
               onMouseEnter={(e) => {
                 e.currentTarget.style.color = '#fff';
-                e.currentTarget.style.borderColor = 'rgba(229,57,53,0.5)';
-                e.currentTarget.style.background = 'rgba(229,57,53,0.08)';
+                e.currentTarget.style.borderColor = 'rgba(155,123,247,0.5)';
+                e.currentTarget.style.background = 'rgba(155,123,247,0.10)';
               }}
               onMouseLeave={(e) => {
                 e.currentTarget.style.color = 'rgba(255,255,255,0.85)';
@@ -231,8 +232,8 @@ export default function Footer() {
               className="w-8 h-8 inline-flex items-center justify-center rounded-[8px] text-white/70 hover:text-white transition-all no-underline"
               style={{ border: '1px solid rgba(255,255,255,0.12)' }}
               onMouseEnter={(e) => {
-                e.currentTarget.style.borderColor = 'rgba(229,57,53,0.45)';
-                e.currentTarget.style.background = 'rgba(229,57,53,0.08)';
+                e.currentTarget.style.borderColor = 'rgba(155,123,247,0.45)';
+                e.currentTarget.style.background = 'rgba(155,123,247,0.10)';
               }}
               onMouseLeave={(e) => {
                 e.currentTarget.style.borderColor = 'rgba(255,255,255,0.12)';

--- a/app/components/Footer.tsx
+++ b/app/components/Footer.tsx
@@ -3,7 +3,7 @@
 import Link from 'next/link';
 import { useState } from 'react';
 
-const ACCENT = '#9b7bf7';
+const ACCENT = '#e53935';
 const EMAIL = 'hello@elixpo.com';
 const REPO_URL = 'https://github.com/elixpo/elixpourl';
 const LICENSE_URL = `${REPO_URL}/blob/main/LICENSE`;
@@ -162,8 +162,8 @@ export default function Footer() {
               }}
               onMouseEnter={(e) => {
                 e.currentTarget.style.color = '#fff';
-                e.currentTarget.style.borderColor = 'rgba(155,123,247,0.5)';
-                e.currentTarget.style.background = 'rgba(155,123,247,0.10)';
+                e.currentTarget.style.borderColor = 'rgba(229,57,53,0.5)';
+                e.currentTarget.style.background = 'rgba(229,57,53,0.08)';
               }}
               onMouseLeave={(e) => {
                 e.currentTarget.style.color = 'rgba(255,255,255,0.85)';
@@ -232,8 +232,8 @@ export default function Footer() {
               className="w-8 h-8 inline-flex items-center justify-center rounded-[8px] text-white/70 hover:text-white transition-all no-underline"
               style={{ border: '1px solid rgba(255,255,255,0.12)' }}
               onMouseEnter={(e) => {
-                e.currentTarget.style.borderColor = 'rgba(155,123,247,0.45)';
-                e.currentTarget.style.background = 'rgba(155,123,247,0.10)';
+                e.currentTarget.style.borderColor = 'rgba(229,57,53,0.45)';
+                e.currentTarget.style.background = 'rgba(229,57,53,0.08)';
               }}
               onMouseLeave={(e) => {
                 e.currentTarget.style.borderColor = 'rgba(255,255,255,0.12)';

--- a/app/components/Navbar.tsx
+++ b/app/components/Navbar.tsx
@@ -5,7 +5,7 @@ import { usePathname } from 'next/navigation';
 import { useEffect, useState } from 'react';
 
 const REPO_URL = 'https://github.com/elixpo/elixpourl';
-const ACCENT = '#9b7bf7';
+const ACCENT = '#e53935';
 
 const Icons = {
   about: (
@@ -105,7 +105,7 @@ export default function Navbar() {
               className="inline-flex items-center gap-2 px-3 py-2 rounded-lg no-underline transition-colors"
               style={{
                 color: isActive(l.href) ? '#111' : '#555',
-                background: isActive(l.href) ? 'rgba(155,123,247,0.10)' : 'transparent',
+                background: isActive(l.href) ? 'var(--accent-dim)' : 'transparent',
               }}
             >
               <span style={{ color: isActive(l.href) ? ACCENT : 'currentColor' }}>{l.icon}</span>
@@ -135,7 +135,7 @@ export default function Navbar() {
             href={isLoggedIn ? '/dashboard' : '/api/auth/login'}
             className="hidden sm:inline-flex items-center gap-2 px-[18px] py-2 rounded-full font-semibold text-sm text-white no-underline transition-colors"
             style={{ background: ACCENT }}
-            onMouseEnter={(e) => (e.currentTarget.style.background = '#7c5cff')}
+            onMouseEnter={(e) => (e.currentTarget.style.background = '#c62828')}
             onMouseLeave={(e) => (e.currentTarget.style.background = ACCENT)}
           >
             {isLoggedIn ? 'Dashboard' : 'Sign in'}
@@ -168,7 +168,7 @@ export default function Navbar() {
               className="inline-flex items-center gap-3 px-3 py-2.5 rounded-lg no-underline text-sm transition-colors"
               style={{
                 color: isActive(l.href) ? '#111' : '#333',
-                background: isActive(l.href) ? 'rgba(155,123,247,0.10)' : 'transparent',
+                background: isActive(l.href) ? 'var(--accent-dim)' : 'transparent',
               }}
             >
               <span style={{ color: isActive(l.href) ? ACCENT : '#888' }}>{l.icon}</span>

--- a/app/components/Navbar.tsx
+++ b/app/components/Navbar.tsx
@@ -5,9 +5,15 @@ import { usePathname } from 'next/navigation';
 import { useEffect, useState } from 'react';
 
 const REPO_URL = 'https://github.com/elixpo/elixpourl';
-const ACCENT = '#e53935';
+const ACCENT = '#9b7bf7';
 
 const Icons = {
+  about: (
+    <svg viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round" className="w-[16px] h-[16px]">
+      <circle cx="10" cy="10" r="7.5" />
+      <path d="M10 9v5M10 6.25h.01" />
+    </svg>
+  ),
   pricing: (
     <svg viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round" className="w-[16px] h-[16px]">
       <path d="M3 7.5L9 2.5a2 2 0 012.6 0l5.4 4.5a2 2 0 01.7 1.5V16a2 2 0 01-2 2H4a2 2 0 01-2-2V9a2 2 0 011-1.5z" />
@@ -46,6 +52,7 @@ const Icons = {
 };
 
 const NAV = [
+  { href: '/about', label: 'About', icon: Icons.about },
   { href: '/pricing', label: 'Pricing', icon: Icons.pricing },
   { href: '/docs', label: 'Docs', icon: Icons.docs },
 ];
@@ -98,7 +105,7 @@ export default function Navbar() {
               className="inline-flex items-center gap-2 px-3 py-2 rounded-lg no-underline transition-colors"
               style={{
                 color: isActive(l.href) ? '#111' : '#555',
-                background: isActive(l.href) ? 'rgba(229,57,53,0.08)' : 'transparent',
+                background: isActive(l.href) ? 'rgba(155,123,247,0.10)' : 'transparent',
               }}
             >
               <span style={{ color: isActive(l.href) ? ACCENT : 'currentColor' }}>{l.icon}</span>
@@ -128,7 +135,7 @@ export default function Navbar() {
             href={isLoggedIn ? '/dashboard' : '/api/auth/login'}
             className="hidden sm:inline-flex items-center gap-2 px-[18px] py-2 rounded-full font-semibold text-sm text-white no-underline transition-colors"
             style={{ background: ACCENT }}
-            onMouseEnter={(e) => (e.currentTarget.style.background = '#c62828')}
+            onMouseEnter={(e) => (e.currentTarget.style.background = '#7c5cff')}
             onMouseLeave={(e) => (e.currentTarget.style.background = ACCENT)}
           >
             {isLoggedIn ? 'Dashboard' : 'Sign in'}
@@ -161,7 +168,7 @@ export default function Navbar() {
               className="inline-flex items-center gap-3 px-3 py-2.5 rounded-lg no-underline text-sm transition-colors"
               style={{
                 color: isActive(l.href) ? '#111' : '#333',
-                background: isActive(l.href) ? 'rgba(229,57,53,0.08)' : 'transparent',
+                background: isActive(l.href) ? 'rgba(155,123,247,0.10)' : 'transparent',
               }}
             >
               <span style={{ color: isActive(l.href) ? ACCENT : '#888' }}>{l.icon}</span>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -14,9 +14,9 @@ const geistMono = Geist_Mono({
 
 const siteUrl = 'https://lixrl.com';
 const title =
-  "ElixpoURL — Fast, Secure URL Shortener with Analytics";
+  'Lixrl — Short Links, Branded Subdomains & Link Analytics';
 const description =
-  "ElixpoURL is a fast, secure, and developer-first URL shortener powered by Cloudflare's global edge network. Create branded short links, track detailed analytics, manage redirects, and integrate seamlessly with modern applications through a reliable API.";
+  'Create fast short links, understand every click, use memorable link names, and give paid links a branded lixrl.com subdomain.';
 
 // Google Search Console — "HTML tag" verification method. Set
 // NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION (the `content` value Google gives you)
@@ -29,41 +29,28 @@ export const metadata: Metadata = {
   metadataBase: new URL(siteUrl),
   title: {
     default: title,
-    template: '%s | ElixpoURL',
+    template: '%s | Lixrl',
   },
   description,
-  applicationName: 'ElixpoURL',
-  alternates: {
-    canonical: '/',
-  },
+  applicationName: 'Lixrl',
+  manifest: '/manifest.webmanifest',
   keywords: [
     'url shortener',
     'link shortener',
     'short links',
-    'elixpo',
-    'elixpourl',
-    'edge network',
-    'edge computing',
-    'cloudflare',
-    'cloudflare workers',
-    'cloudflare d1',
-    'short url api',
-    'developer tools',
-    'developer api',
-    'open source',
     'custom links',
     'branded links',
+    'branded subdomains',
     'url analytics',
     'link analytics',
     'link management',
-    'fast redirects',
     'qr codes',
   ],
   
   authors: [{ name: 'Elixpo', url: 'https://elixpo.com' }],
   creator: 'Elixpo',
   publisher: 'Elixpo',
-  category: 'developer tools',
+  category: 'business',
   ...(googleSiteVerification
     ? { verification: { google: googleSiteVerification } }
     : {}),
@@ -82,15 +69,15 @@ export const metadata: Metadata = {
     type: 'website',
     locale: 'en_US',
     url: siteUrl,
-    siteName: 'ElixpoURL',
+    siteName: 'Lixrl',
     title,
-    description: "Create, manage, and analyze short links with ElixpoURL—a fast, secure, and developer-first URL shortener powered by Cloudflare's global edge network.",
+    description,
     images: [
       {
         url: '/og-image.png',
         width: 1822,
         height: 825,
-        alt: "ElixpoURL — Fast and secure URL shortener",
+        alt: 'Lixrl short links and analytics',
         type: 'image/png',
       },
     ],
@@ -98,7 +85,7 @@ export const metadata: Metadata = {
   twitter: {
     card: 'summary_large_image',
     title,
-    description: "Build faster with ElixpoURL. Shorten links, monitor analytics, manage redirects, and integrate a reliable URL shortening API powered by Cloudflare's edge.",
+    description,
     images: ['/og-image.png'],
     creator: '@elixpo',
     site: '@elixpo',
@@ -107,6 +94,11 @@ export const metadata: Metadata = {
     email: false,
     address: false,
     telephone: false,
+  },
+  appleWebApp: {
+    capable: true,
+    title: 'Lixrl',
+    statusBarStyle: 'default',
   },
   // Icons declared explicitly so they're emitted as <link> tags pointing
   // at static files in public/. Putting these files under app/ (the
@@ -130,13 +122,56 @@ export default function RootLayout({
 }: {
   children: React.ReactNode;
 }) {
+  const structuredData = {
+    '@context': 'https://schema.org',
+    '@graph': [
+      {
+        '@type': 'WebSite',
+        '@id': `${siteUrl}/#website`,
+        name: 'Lixrl',
+        url: siteUrl,
+        description,
+      },
+      {
+        '@type': 'WebApplication',
+        '@id': `${siteUrl}/#application`,
+        name: 'Lixrl',
+        url: siteUrl,
+        description,
+        applicationCategory: 'BusinessApplication',
+        operatingSystem: 'Any',
+        browserRequirements: 'Requires a modern web browser',
+        featureList: [
+          'Short links',
+          'Click analytics',
+          'Custom link names',
+          'QR codes',
+          'Expiring links',
+          'Branded lixrl.com subdomains',
+        ],
+        offers: {
+          '@type': 'Offer',
+          price: '0',
+          priceCurrency: 'USD',
+          description: 'Free account plan',
+        },
+      },
+    ],
+  };
+
   return (
     <html
       lang="en"
       className={`${geistSans.variable} ${geistMono.variable} overflow-x-hidden`}
       suppressHydrationWarning
     >
-      <body className="antialiased overflow-x-hidden font-sans">{children}</body>
+      <body className="antialiased overflow-x-hidden font-sans">
+        {children}
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}
+        />
+      </body>
     </html>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,8 +1,16 @@
+import type { Metadata } from 'next';
 import { redirect } from 'next/navigation';
 import { getCurrentUser } from '@/lib/auth';
 import LandingPageClient from './LandingPageClient';
 
 export const runtime = 'edge';
+
+export const metadata: Metadata = {
+  title: { absolute: 'Lixrl — Short Links, Branded Subdomains & Link Analytics' },
+  description:
+    'Create a short link in one click, keep persistent links with a free account, and add analytics, custom names, or branded subdomains when you need them.',
+  alternates: { canonical: '/' },
+};
 
 /**
  * Landing-page entry point.

--- a/app/pricing/layout.tsx
+++ b/app/pricing/layout.tsx
@@ -1,0 +1,27 @@
+import type { Metadata } from 'next';
+
+const description =
+  'Compare Lixrl Free, Pro, and Business plans, including link limits, analytics history, custom names, QR options, and branded subdomains.';
+
+export const metadata: Metadata = {
+  title: 'Pricing',
+  description,
+  alternates: { canonical: '/pricing' },
+  openGraph: {
+    type: 'website',
+    url: '/pricing',
+    title: 'Lixrl pricing — Free, Pro, and Business',
+    description,
+    images: [{ url: '/og-image.png', width: 1822, height: 825, alt: 'Lixrl pricing' }],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Lixrl pricing — Free, Pro, and Business',
+    description,
+    images: ['/og-image.png'],
+  },
+};
+
+export default function PricingLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/app/pricing/page.tsx
+++ b/app/pricing/page.tsx
@@ -13,7 +13,7 @@ import {
   TIER_PRICING,
 } from '@/lib/types';
 
-const ACCENT = '#9b7bf7';
+const ACCENT = '#e53935';
 
 const PLAN_GUIDANCE: Record<SellableTier, string> = {
   free: 'For personal links and trying Lixrl.',
@@ -175,7 +175,7 @@ export default function PricingPage() {
               />
               <span
                 className="text-[0.7rem] font-bold px-2 py-1 rounded-full whitespace-nowrap"
-                style={{ background: 'rgba(155,123,247,0.12)', color: '#6f52d9', border: '1px solid rgba(155,123,247,0.28)' }}
+                style={{ background: 'var(--accent-dim)', color: 'var(--accent-deep)', border: '1px solid var(--accent-border)' }}
               >
                 2 months free
               </span>
@@ -193,7 +193,7 @@ export default function PricingPage() {
         )}
 
         {/* One offer panel keeps prices and actions comparable without scrolling. */}
-        <section className="mt-6 grid grid-cols-1 overflow-hidden rounded-[22px] border border-[#ded8f2] bg-white shadow-[0_20px_60px_rgba(74,52,130,0.10)] md:grid-cols-3">
+        <section className="mt-6 grid grid-cols-1 overflow-hidden rounded-[22px] border border-[#e3e3e3] bg-white shadow-[0_20px_60px_rgba(0,0,0,0.08)] md:grid-cols-3">
           {SELLABLE_TIER_ORDER.map((tier) => {
             const p = TIER_PRICING[tier];
             const amount = p.price[currency][interval];
@@ -202,13 +202,13 @@ export default function PricingPage() {
             return (
               <div
                 key={tier}
-                className="relative flex flex-col border-t border-[#ece8f7] p-5 first:border-t-0 md:min-h-[430px] md:border-l md:border-t-0 md:first:border-l-0 lg:p-6"
+                className="relative flex flex-col border-t border-[#ececec] p-5 first:border-t-0 md:min-h-[430px] md:border-l md:border-t-0 md:first:border-l-0 lg:p-6"
                 style={{
                   // Current plan is greyed/dimmed — it's not an upgrade target.
                   background: isCurrent
                     ? 'linear-gradient(135deg, rgba(0,0,0,0.04) 0%, rgba(250,250,250,0.9) 100%)'
                     : isPopular
-                      ? 'linear-gradient(145deg, rgba(155,123,247,0.16) 0%, rgba(124,92,255,0.04) 100%)'
+                      ? 'linear-gradient(145deg, rgba(229,57,53,0.13) 0%, rgba(198,40,40,0.03) 100%)'
                       : 'linear-gradient(135deg, rgba(255,255,255,0.96) 0%, rgba(250,250,250,0.92) 100%)',
                   backdropFilter: 'blur(20px)',
                   opacity: isCurrent ? 0.6 : 1,
@@ -224,7 +224,7 @@ export default function PricingPage() {
                 ) : isPopular ? (
                   <span
                     className="absolute right-4 top-4 rounded-full px-3 py-1 text-[10px] font-bold uppercase tracking-wider text-white"
-                    style={{ background: 'linear-gradient(135deg, #9b7bf7 0%, #7c5cff 100%)' }}
+                    style={{ background: 'linear-gradient(135deg, #e53935 0%, #c62828 100%)' }}
                   >
                     Most popular
                   </span>
@@ -287,7 +287,7 @@ export default function PricingPage() {
 
         <section className="mt-14" aria-labelledby="compare-plans">
           <div className="max-w-2xl">
-            <p className="text-[11px] font-bold uppercase tracking-[0.12em] text-[#7052d6]">Plan details</p>
+            <p className="text-[11px] font-bold uppercase tracking-[0.12em] text-[#c62828]">Plan details</p>
             <h2 id="compare-plans" className="mt-2 text-2xl font-extrabold tracking-tight text-[#111] md:text-3xl">
               Compare every limit
             </h2>
@@ -321,7 +321,7 @@ export default function PricingPage() {
 
         <section className="mx-auto mt-16 max-w-3xl" aria-labelledby="pricing-faq">
           <div className="text-center">
-            <p className="text-[11px] font-bold uppercase tracking-[0.12em] text-[#7052d6]">Before you choose</p>
+            <p className="text-[11px] font-bold uppercase tracking-[0.12em] text-[#c62828]">Before you choose</p>
             <h2 id="pricing-faq" className="mt-2 text-2xl font-extrabold tracking-tight text-[#111] md:text-3xl">Pricing questions, answered</h2>
           </div>
           <div className="mt-7 divide-y divide-[#e8e8e8] rounded-2xl border border-[#e5e5e5] px-5 md:px-7">
@@ -389,7 +389,7 @@ function Toggle({
           className="px-3.5 py-1.5 rounded-[9px] text-[0.82rem] font-semibold transition-all cursor-pointer border-none"
           style={
             value === o.value
-              ? { background: 'linear-gradient(135deg, #9b7bf7 0%, #7c5cff 100%)', color: '#fff' }
+              ? { background: 'linear-gradient(135deg, #e53935 0%, #c62828 100%)', color: '#fff' }
               : { background: 'transparent', color: 'rgba(0,0,0,0.6)' }
           }
         >
@@ -458,9 +458,9 @@ function CtaButton({
         background: isCurrentPlanCta
           ? 'rgba(0,0,0,0.06)'
           : filled
-            ? 'linear-gradient(135deg, #9b7bf7 0%, #7c5cff 100%)'
+            ? 'linear-gradient(135deg, #e53935 0%, #c62828 100%)'
             : 'transparent',
-        boxShadow: filled && !disabled ? '0 6px 18px rgba(124,92,255,0.28)' : 'none',
+        boxShadow: filled && !disabled ? '0 6px 18px rgba(229,57,53,0.24)' : 'none',
         border: isCurrentPlanCta
           ? '1px solid rgba(0,0,0,0.1)'
           : filled

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -21,7 +21,7 @@ export default function robots(): MetadataRoute.Robots {
     rules: [
       {
         userAgent: '*',
-        allow: ['/', '/pricing', '/docs', '/privacy', '/terms'],
+        allow: ['/', '/about', '/pricing', '/docs', '/privacy', '/terms'],
         disallow: [
           '/api/',
           '/dashboard',

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -24,6 +24,12 @@ export default function sitemap(): MetadataRoute.Sitemap {
       priority: 0.9,
     },
     {
+      url: `${BASE_URL}/about`,
+      lastModified: now,
+      changeFrequency: 'monthly',
+      priority: 0.8,
+    },
+    {
       url: `${BASE_URL}/docs`,
       lastModified: now,
       changeFrequency: 'weekly',
@@ -48,6 +54,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
     'api',
     'keys',
     'analytics',
+    'subdomains',
     'webhooks',
     'errors',
     'self-hosting',


### PR DESCRIPTION
## What this does
Adds a static `/about` page that explains what Lixrl does, how the link workflow works, and where it provides a clearer experience. Adds direct navigation and improves how public pages appear to search engines and link previews.

## Changes
- Add a responsive, server-rendered About page with factual product differentiation and no competitor references.
- Link About from desktop/mobile navigation and the footer.
- Align shared navigation accents with the purple Lixrl brand.
- Replace technical, keyword-heavy global metadata with concise product language.
- Add route-specific homepage, About, and Pricing canonicals plus social previews.
- Add WebSite, WebApplication, and AboutPage structured data.
- Add About and subdomain documentation to sitemap/robots coverage.

## Performance
- No page-specific client component, animation library, image request, or data fetch was added.
- About content is statically renderable.

## Verification
- `git diff --check` passed.
- Competitor-name scan returned no matches.
- Build and npm checks deferred per request.

---
Fixes #33