### PR TITLE
[ELIXPO] Make QR generation tool-first

### DIFF
--- a/app/generate/QrGenerator.tsx
+++ b/app/generate/QrGenerator.tsx
@@ -179,10 +179,10 @@ export default function QrGenerator() {
   };
 
   return (
-    <div className="grid gap-6 lg:grid-cols-[minmax(0,1.15fr)_minmax(320px,0.85fr)]">
+    <div className="grid flex-1 gap-4 lg:grid-cols-[minmax(0,1.15fr)_minmax(320px,0.85fr)] lg:items-stretch">
       <form
         onSubmit={generate}
-        className="rounded-3xl border border-[#e5e5e5] bg-white p-5 shadow-[0_18px_55px_rgba(0,0,0,0.07)] md:p-7"
+        className="rounded-3xl border border-[#e3e3e3] bg-white p-4 shadow-[0_16px_45px_rgba(0,0,0,0.06)] md:p-5"
       >
         <label htmlFor="qr-destination" className="text-sm font-bold text-[#222]">
           Link to turn into a QR code
@@ -207,8 +207,8 @@ export default function QrGenerator() {
           </button>
         </div>
 
-        <div className="mt-7">
-          <div className="flex items-end justify-between gap-4">
+        <div className="mt-5">
+          <div className="flex items-center justify-between gap-4">
             <h2 className="text-sm font-bold text-[#222]">Choose a style</h2>
             {!paid && (
               <Link href="/pricing" className="text-xs font-semibold text-[#c62828] no-underline">
@@ -216,7 +216,7 @@ export default function QrGenerator() {
               </Link>
             )}
           </div>
-          <div className="mt-3 grid grid-cols-2 gap-2 sm:grid-cols-4">
+          <div className="mt-3 flex flex-wrap gap-2">
             {QR_PRESETS.map((preset, index) => {
               const locked = account.presetLimit !== -1 && index >= account.presetLimit;
               const selected = preset.id === presetId;
@@ -234,30 +234,34 @@ export default function QrGenerator() {
                     setError('');
                     setPresetId(preset.id);
                   }}
-                  className="relative flex min-h-16 items-end overflow-hidden rounded-xl border p-3 text-left transition-all"
+                  className="group inline-flex h-10 items-center gap-2 rounded-full border px-3 text-left text-xs font-bold transition-all"
                   style={{
                     borderColor: selected ? '#e53935' : '#e1e1e1',
-                    background: preset.swatch,
-                    opacity: locked ? 0.45 : 1,
-                    boxShadow: selected ? '0 0 0 2px rgba(229,57,53,0.14)' : 'none',
+                    background: selected ? '#fff6f5' : '#ffffff',
+                    color: locked ? '#888' : '#222',
+                    boxShadow: selected ? '0 0 0 2px rgba(229,57,53,0.12)' : '0 1px 2px rgba(0,0,0,0.03)',
                   }}
                 >
-                  <span className="rounded-md bg-white/90 px-2 py-1 text-[11px] font-bold text-[#222] shadow-sm">
-                    {preset.name}{locked ? ' · Pro' : ''}
+                  <span
+                    className="relative h-6 w-6 shrink-0 overflow-hidden rounded-full border border-black/10"
+                    style={{ background: preset.swatch, opacity: locked ? 0.55 : 1 }}
+                    aria-hidden="true"
+                  >
+                    <span className="absolute inset-[6px] rounded-[2px] border-2 border-white/90" />
                   </span>
+                  <span>{preset.name}</span>
+                  {locked && <span className="rounded-full bg-[#f1f1f1] px-1.5 py-0.5 text-[9px] uppercase tracking-wide text-[#777]">Pro</span>}
+                  {selected && !locked && <span className="flex h-4 w-4 items-center justify-center rounded-full bg-[#e53935] text-[10px] text-white" aria-hidden="true">✓</span>}
                 </button>
               );
             })}
           </div>
         </div>
 
-        <div className="mt-7 grid gap-4 sm:grid-cols-2">
-          <div className="rounded-2xl border border-[#e5e5e5] p-4">
+        <div className="mt-5 grid gap-2 sm:grid-cols-2">
+          <div className="rounded-2xl border border-[#e5e5e5] bg-[#fcfcfc] p-3">
             <div className="flex items-center justify-between gap-3">
-              <div>
-                <div className="text-sm font-bold text-[#222]">Add a logo</div>
-                <p className="mt-1 text-xs leading-5 text-[#777]">Place a public image in the center.</p>
-              </div>
+              <div className="text-sm font-bold text-[#222]">Center logo</div>
               {!account.allowLogo && <span className="rounded-full bg-[#f5f5f5] px-2 py-1 text-[10px] font-bold text-[#777]">PRO</span>}
             </div>
             {account.allowLogo ? (
@@ -266,25 +270,22 @@ export default function QrGenerator() {
                 value={logoUrl}
                 onChange={(event) => setLogoUrl(event.target.value)}
                 placeholder="https://site.com/logo.png"
-                className="mt-3 w-full rounded-lg border border-[#dddddd] px-3 py-2 text-xs outline-none focus:border-[#e53935]"
+                className="mt-2 w-full rounded-lg border border-[#dddddd] px-3 py-2 text-xs outline-none focus:border-[#e53935]"
               />
             ) : (
-              <Link href="/pricing" className="mt-3 inline-flex text-xs font-semibold text-[#c62828] no-underline">
-                Upgrade to add a logo →
+              <Link href="/pricing" className="mt-2 inline-flex text-xs font-semibold text-[#c62828] no-underline">
+                Unlock logo →
               </Link>
             )}
           </div>
 
-          <div className="rounded-2xl border border-[#e5e5e5] p-4">
+          <div className="rounded-2xl border border-[#e5e5e5] bg-[#fcfcfc] p-3">
             <div className="flex items-center justify-between gap-3">
-              <div>
-                <div className="text-sm font-bold text-[#222]">Track QR scans</div>
-                <p className="mt-1 text-xs leading-5 text-[#777]">Use a short link with dashboard analytics.</p>
-              </div>
+              <div className="text-sm font-bold text-[#222]">Scan analytics</div>
               {!paid && <span className="rounded-full bg-[#f5f5f5] px-2 py-1 text-[10px] font-bold text-[#777]">PAID</span>}
             </div>
             {paid ? (
-              <label className="mt-3 flex cursor-pointer items-center gap-2 text-xs font-semibold text-[#444]">
+              <label className="mt-2 flex cursor-pointer items-center gap-2 text-xs font-semibold text-[#444]">
                 <input
                   type="checkbox"
                   checked={trackScans}
@@ -296,7 +297,7 @@ export default function QrGenerator() {
             ) : (
               <Link
                 href={account.loggedIn ? '/pricing' : '/api/auth/login?return_to=%2Fgenerate'}
-                className="mt-3 inline-flex text-xs font-semibold text-[#c62828] no-underline"
+                className="mt-2 inline-flex text-xs font-semibold text-[#c62828] no-underline"
               >
                 {account.loggedIn ? 'Upgrade for scan analytics →' : 'Sign in to view options →'}
               </Link>
@@ -311,7 +312,7 @@ export default function QrGenerator() {
         )}
       </form>
 
-      <aside className="flex min-h-[420px] flex-col items-center justify-center rounded-3xl border border-[#e5e5e5] bg-[#fafafa] p-6 text-center">
+      <aside className="flex min-h-[320px] flex-col items-center justify-center rounded-3xl border border-[#e5e5e5] bg-[#fafafa] p-5 text-center lg:min-h-0">
         {qrData ? (
           <>
             <div className="rounded-2xl bg-white p-3 shadow-[0_12px_35px_rgba(0,0,0,0.10)]">
@@ -380,8 +381,7 @@ export default function QrGenerator() {
                 <span key={index} className="rounded-sm bg-[#222]" style={{ opacity: index === 4 ? 0.15 : 1 }} />
               ))}
             </div>
-            <h2 className="mt-5 text-lg font-bold">Your QR code appears here</h2>
-            <p className="mt-2 text-sm leading-6 text-[#777]">Enter a link, choose a style, and generate a print-ready QR code.</p>
+            <h2 className="mt-5 text-base font-bold">Your QR code appears here</h2>
           </div>
         )}
       </aside>

--- a/app/generate/page.tsx
+++ b/app/generate/page.tsx
@@ -128,50 +128,23 @@ export default function QrCodeGeneratorPage() {
       <Navbar />
 
       <main>
-        <section className="mx-auto w-full max-w-6xl px-4 pb-12 pt-12 text-center md:px-6 md:pb-14 md:pt-16">
-          <p className="text-xs font-bold uppercase tracking-[0.16em] text-[#c62828]">
-            Free URL to QR code tool
-          </p>
-          <h1 className="mx-auto mt-4 max-w-4xl text-[2.55rem] font-extrabold leading-[1.03] tracking-[-0.045em] sm:text-6xl">
-            Quick QR code generator for any link
-          </h1>
-          <p className="mx-auto mt-5 max-w-2xl text-base leading-7 text-[#666] md:text-lg">
-            Paste a URL, choose a style, and download a sharp QR code. Upgrade when you need custom branding or scan analytics.
-          </p>
-        </section>
-
-        <section className="mx-auto w-full max-w-6xl px-4 pb-20 md:px-6" aria-label="QR code generator">
-          <QrGenerator />
-          <p className="mt-4 text-center text-xs leading-5 text-[#777]">
-            Basic QR codes are created in your browser. A destination is sent to Lixrl only when a paid member chooses scan tracking.
-          </p>
-        </section>
-
-        <section className="border-y border-[#e8e8e8] bg-[#fafafa]" aria-labelledby="how-qr-works">
-          <div className="mx-auto w-full max-w-6xl px-4 py-16 md:px-6 md:py-20">
-            <div className="max-w-2xl">
-              <p className="text-xs font-bold uppercase tracking-[0.16em] text-[#c62828]">How it works</p>
-              <h2 id="how-qr-works" className="mt-3 text-3xl font-extrabold tracking-tight md:text-4xl">
-                From link to QR code in three steps
-              </h2>
+        <section
+          className="mx-auto flex min-h-[calc(100svh-72px)] w-full max-w-7xl flex-col px-4 pb-10 pt-6 md:px-6 md:pt-8"
+          aria-labelledby="qr-generator-heading"
+        >
+          <div className="mb-5 flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+            <div>
+              <h1 id="qr-generator-heading" className="text-3xl font-extrabold tracking-[-0.035em] sm:text-4xl">
+                Create a QR code
+              </h1>
+              <p className="mt-1 text-sm text-[#777]">Paste a link. Pick a style. Download instantly.</p>
             </div>
-            <ol className="mt-10 grid gap-4 md:grid-cols-3">
-              {[
-                ['1', 'Paste your link', 'Use a complete destination beginning with http:// or https://.'],
-                ['2', 'Choose the look', 'Start with a free style, or use a paid plan for every style and a center logo.'],
-                ['3', 'Download and share', 'Export SVG for print, PNG for crisp digital use, or a compact JPEG for quick sharing.'],
-              ].map(([number, heading, body]) => (
-                <li key={number} className="list-none rounded-2xl border border-[#e5e5e5] bg-white p-6">
-                  <span className="font-mono text-xs font-bold text-[#c62828]">{number.padStart(2, '0')}</span>
-                  <h3 className="mt-5 text-lg font-bold">{heading}</h3>
-                  <p className="mt-2 text-sm leading-6 text-[#6b6b6b]">{body}</p>
-                </li>
-              ))}
-            </ol>
+            <p className="text-xs font-semibold text-[#777]">Free · No account required</p>
           </div>
+          <QrGenerator />
         </section>
 
-        <section className="mx-auto grid w-full max-w-6xl gap-10 px-4 py-16 md:px-6 md:py-24 lg:grid-cols-[0.8fr_1.2fr]" aria-labelledby="tracked-qr-codes">
+        <section className="border-t border-[#e8e8e8] mx-auto grid w-full max-w-6xl gap-10 px-4 py-16 md:px-6 md:py-24 lg:grid-cols-[0.8fr_1.2fr]" aria-labelledby="tracked-qr-codes">
           <div>
             <p className="text-xs font-bold uppercase tracking-[0.16em] text-[#c62828]">Optional scan tracking</p>
             <h2 id="tracked-qr-codes" className="mt-3 text-3xl font-extrabold tracking-tight md:text-4xl">


### PR DESCRIPTION
## Summary

- replace the oversized generator intro with a compact task heading
- make the form and preview fill the initial large-screen viewport
- redesign styles as compact visual chips with selected and Pro states
- condense logo and scan-analytics controls
- remove the redundant three-step section and top-level helper copy
- retain useful QR and tracking content below the tool for search coverage

## Verification

- whitespace validation passed
- route metadata and structured data remain unchanged
- no API, entitlement, or generation behavior changed
- build and npm checks deferred to the maintainer as requested

Fixes #37