### PR TITLE
[ELIXPO] Preserve intentional homepage visits

### DIFF
--- a/app/components/Navbar.tsx
+++ b/app/components/Navbar.tsx
@@ -90,7 +90,7 @@ export default function Navbar() {
     >
       <div className="max-w-7xl mx-auto px-4 md:px-6 h-[60px] flex items-center gap-3">
         {/* Brand */}
-        <Link href="/" className="flex items-center gap-2.5 no-underline text-[#111] shrink-0">
+        <Link href="/?noredirect=1" className="flex items-center gap-2.5 no-underline text-[#111] shrink-0">
           <img src="/base_logo.png" alt="ElixpoURL" width={30} height={30} className="rounded-lg" />
           <span className="font-bold text-[1.05rem] tracking-tight text-[#111]">
             Elixpo<span style={{ color: ACCENT }}>URL</span>

--- a/app/components/Sidebar.tsx
+++ b/app/components/Sidebar.tsx
@@ -39,6 +39,14 @@ const Icons = {
       <path d="M10 7v6M7 10h6" />
     </svg>
   ),
+  qr: (
+    <svg viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" className="w-[18px] h-[18px]">
+      <rect x="2.5" y="2.5" width="5.5" height="5.5" rx="1" />
+      <rect x="12" y="2.5" width="5.5" height="5.5" rx="1" />
+      <rect x="2.5" y="12" width="5.5" height="5.5" rx="1" />
+      <path d="M12 12h2v2h3.5M12 17.5v-2h2" />
+    </svg>
+  ),
   user: (
     <svg viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" className="w-[18px] h-[18px]">
       <circle cx="10" cy="7" r="3.5" />
@@ -109,6 +117,7 @@ const navItems = [
   { href: '/dashboard', label: 'Dashboard', icon: Icons.dashboard },
   { href: '/dashboard/urls', label: 'My URLs', icon: Icons.link },
   { href: '/dashboard/new', label: 'Shorten URL', icon: Icons.plus },
+  { href: '/generate', label: 'QR Generator', icon: Icons.qr },
   { href: '/dashboard/domains', label: 'Subdomains', icon: Icons.domain },
 ];
 
@@ -120,6 +129,7 @@ const accountItems = [
 
 // Secondary links shown lower in the dropdown.
 const resourceItems = [
+  { href: '/generate', label: 'Generate QR code', icon: Icons.qr },
   { href: '/pricing', label: 'Plans & pricing', icon: Icons.sparkle },
   { href: '/docs', label: 'Docs', icon: Icons.docs },
 ];
@@ -177,7 +187,7 @@ export default function Sidebar({ user }: { user: User }) {
       style={{ background: 'rgba(255,255,255,0.92)', backdropFilter: 'blur(20px)' }}
     >
       {/* Left: Logo */}
-      <Link href="/" className="flex items-center gap-2 no-underline shrink-0">
+      <Link href="/?noredirect=1" className="flex items-center gap-2 no-underline shrink-0">
         <Image src="/logo.png" alt="ElixpoURL" width={26} height={26} className="rounded-lg" />
         <span className="text-base font-sans font-bold text-text-primary hidden sm:inline">
           <span className="text-accent-main">Elixpo</span>URL

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -17,14 +17,23 @@ export const metadata: Metadata = {
  *
  * Server-side auth check before rendering the marketing surface — signed-in
  * users are sent straight to `/dashboard` so they don't have to click
- * through the hero. Anonymous visitors get the full landing page.
+ * through the hero. `?noredirect=1` is the explicit escape hatch used by
+ * authenticated navigation when someone chooses to explore the homepage.
  *
  * `getCurrentUser()` is cheap (KV session lookup → D1 fallback) and runs
  * at the edge, so the redirect adds no perceptible latency.
  */
-export default async function Page() {
+export default async function Page({
+  searchParams,
+}: {
+  searchParams: Promise<{ noredirect?: string | string[] }>;
+}) {
+  const params = await searchParams;
+  const noRedirect = Array.isArray(params.noredirect)
+    ? params.noredirect.includes('1')
+    : params.noredirect === '1';
   const user = await getCurrentUser();
-  if (user) {
+  if (user && !noRedirect) {
     redirect('/dashboard');
   }
   return <LandingPageClient />;


### PR DESCRIPTION
## Summary

- honor ?noredirect=1 on the authenticated homepage entry point
- keep the default signed-in visit to / redirecting to /dashboard
- attach the opt-out query to dashboard and public brand-logo links
- add QR Generator to the authenticated dashboard navbar
- add Generate QR code to the profile resource menu
- preserve existing landing-page and footer QR links

## Verification

- whitespace validation passed
- the landing page remains canonical at /
- the redirect decision remains server-side at the edge
- no authentication, QR generation, or entitlement behavior changed
- build and npm checks deferred to the maintainer as requested

Fixes #43