### PR TITLE
[ELIXPO] Add complete Lixrl management commands

### DIFF
--- a/packages/lixrl-cli/README.md
+++ b/packages/lixrl-cli/README.md
@@ -11,3 +11,16 @@ lixrl whoami
 Create a read/write API key at [lixrl.com/profile/keys](https://lixrl.com/profile/keys). Interactive login stores the key in the operating-system keychain. CI can provide `LIXRL_API_KEY` without writing it to disk.
 
 Use `lixrl --help` for the complete command list. `shortner` is provided as a compatibility alias.
+
+## Core workflows
+
+```bash
+lixrl urls create https://example.com/launch --title "Launch" --tag campaign
+lixrl urls list --search launch --json
+lixrl urls analytics abc123 --days 30
+lixrl urls export --output links.csv
+lixrl keys create --name deploy --scopes read,write
+lixrl domains claim team
+```
+
+Deletion, API-key revocation, mapping removal, and file replacement require `--yes`. Use `--json --no-input` for automation.

--- a/packages/lixrl-cli/bin/shortner.mjs
+++ b/packages/lixrl-cli/bin/shortner.mjs
@@ -6,6 +6,7 @@ import { CredentialStore, validateKey } from '../src/credentials.js';
 import { LixrlClient } from '../src/client.js';
 import { emit, fail, EXIT_CODES } from '../src/contract.js';
 import { openBrowser, promptSecret } from '../src/ui.js';
+import { runDomains, runKeys, runUrls } from '../src/commands.js';
 
 const VERSION = '1.0.1';
 const OPTIONS = {
@@ -16,6 +17,30 @@ const OPTIONS = {
   'no-input': { type: 'boolean', default: false },
   open: { type: 'boolean', default: false },
   yes: { type: 'boolean', short: 'y', default: false },
+  force: { type: 'boolean', default: false },
+  limit: { type: 'string' },
+  offset: { type: 'string' },
+  search: { type: 'string' },
+  destination: { type: 'string' },
+  slug: { type: 'string' },
+  title: { type: 'string' },
+  'clear-title': { type: 'boolean', default: false },
+  campaign: { type: 'string' },
+  'clear-campaign': { type: 'boolean', default: false },
+  tag: { type: 'string', multiple: true },
+  'clear-tags': { type: 'boolean', default: false },
+  expires: { type: 'string' },
+  'clear-expiry': { type: 'boolean', default: false },
+  'utm-source': { type: 'string' },
+  'utm-medium': { type: 'string' },
+  'utm-campaign': { type: 'string' },
+  'utm-term': { type: 'string' },
+  'utm-content': { type: 'string' },
+  days: { type: 'string' },
+  file: { type: 'string' },
+  output: { type: 'string', short: 'o' },
+  name: { type: 'string' },
+  scopes: { type: 'string' },
   help: { type: 'boolean', short: 'h', default: false },
   version: { type: 'boolean', short: 'v', default: false },
 };
@@ -28,6 +53,16 @@ Usage:
   lixrl whoami [--profile <name>] [--json]
   lixrl profiles [--json]
   lixrl use <profile> [--json]
+  lixrl urls list [--limit 50] [--search <text>]
+  lixrl urls create <destination> [--slug <code>] [--title <title>]
+  lixrl urls get|delete|enable|disable|analytics <code>
+  lixrl urls update <code> [--destination <url>] [--title <title>]
+  lixrl urls bulk-create --file <links.json>
+  lixrl urls bulk-delete <code...> --yes
+  lixrl urls export [--output <file.csv>]
+  lixrl urls export-clicks <code> [--output <file.csv>]
+  lixrl keys list|create|revoke
+  lixrl domains list|claim|verify|default|remove|links|map|unmap
 
 Authentication:
   Create a read/write API key at https://lixrl.com/profile/keys. Login stores it
@@ -47,7 +82,7 @@ Global flags:
 async function main(argv = process.argv.slice(2)) {
   const parsed = parseArgs({ args: argv, options: OPTIONS, allowPositionals: true, strict: false });
   const options = parsed.values;
-  const [command, subcommand] = parsed.positionals;
+  const [command, subcommand, ...args] = parsed.positionals;
   if (options.version) return process.stdout.write(`${VERSION}\n`);
   if (options.help || !command) return process.stdout.write(HELP);
 
@@ -91,6 +126,10 @@ async function main(argv = process.argv.slice(2)) {
     const user = await new LixrlClient({ apiUrl: config.apiUrl, apiKey: key }).me();
     return emit({ profile, ...user }, options);
   }
+  const client = new LixrlClient({ apiUrl: config.apiUrl, apiKey: key });
+  if (['url', 'urls', 'links'].includes(command)) return runUrls(client, subcommand, args, options);
+  if (['key', 'keys'].includes(command)) return runKeys(client, subcommand, args, options);
+  if (['domain', 'domains', 'subdomains'].includes(command)) return runDomains(client, subcommand, args, options);
 
   throw Object.assign(new Error(`Unknown command: ${command}`), { code: 'unknown_command', exitCode: EXIT_CODES.USAGE });
 }

--- a/packages/lixrl-cli/src/commands.js
+++ b/packages/lixrl-cli/src/commands.js
@@ -1,0 +1,177 @@
+import { readFile, writeFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { emit, EXIT_CODES, requireConfirmation } from './contract.js';
+
+function usage(message) {
+  throw Object.assign(new Error(message), { code: 'invalid_usage', exitCode: EXIT_CODES.USAGE });
+}
+
+function required(value, message) {
+  if (!value) usage(message);
+  return value;
+}
+
+function positive(value, fallback) {
+  if (value === undefined) return fallback;
+  const number = Number(value);
+  if (!Number.isSafeInteger(number) || number < 0) usage(`Expected a non-negative integer, received "${value}".`);
+  return number;
+}
+
+function query(path, values) {
+  const params = new URLSearchParams();
+  for (const [key, value] of Object.entries(values)) {
+    if (value !== undefined && value !== '') params.set(key, String(value));
+  }
+  const suffix = params.toString();
+  return suffix ? `${path}?${suffix}` : path;
+}
+
+function pathPart(value) {
+  return encodeURIComponent(required(value, 'A resource identifier is required.'));
+}
+
+function urlInput(destination, options) {
+  const body = {
+    url: required(destination, 'Usage: lixrl urls create <destination> [options]'),
+    ...(options.slug ? { custom_code: options.slug } : {}),
+    ...(options.title ? { title: options.title } : {}),
+    ...(options.expires ? { expires_at: options.expires } : {}),
+    ...(options.campaign ? { campaign: options.campaign } : {}),
+    ...(options.tag?.length ? { tags: options.tag } : {}),
+  };
+  const utm = Object.fromEntries(['source', 'medium', 'campaign', 'term', 'content']
+    .map((key) => [key, options[`utm-${key}`]])
+    .filter(([, value]) => value));
+  if (Object.keys(utm).length) body.utm = utm;
+  return body;
+}
+
+async function writeResponse(response, output, options) {
+  const content = Buffer.from(await response.arrayBuffer());
+  if (!output) {
+    process.stdout.write(content);
+    return;
+  }
+  if (existsSync(output) && !(options.force && options.yes)) {
+    usage(`Refusing to overwrite ${output}. Pass --force --yes to replace it.`);
+  }
+  await writeFile(output, content);
+  emit({ output, bytes: content.byteLength }, options);
+}
+
+export async function runUrls(client, action, args, options) {
+  const code = args[0];
+  switch (action) {
+    case 'list':
+      return emit(await client.request(query('/api/urls', {
+        limit: positive(options.limit, 50), offset: positive(options.offset, 0), search: options.search,
+      })), options);
+    case 'get':
+      return emit(await client.request(`/api/urls/${pathPart(code)}`), options);
+    case 'create':
+      return emit(await client.request('/api/urls', { method: 'POST', body: urlInput(code, options) }), options);
+    case 'update': {
+      required(code, 'Usage: lixrl urls update <code> [options]');
+      const body = {
+        ...(options.destination ? { url: options.destination } : {}),
+        ...(options.title ? { title: options.title } : {}),
+        ...(options['clear-title'] ? { title: null } : {}),
+        ...(options.campaign ? { campaign: options.campaign } : {}),
+        ...(options['clear-campaign'] ? { campaign: null } : {}),
+        ...(options.tag?.length ? { tags: options.tag } : {}),
+        ...(options['clear-tags'] ? { tags: [] } : {}),
+        ...(options.expires ? { expires_at: options.expires } : {}),
+        ...(options['clear-expiry'] ? { expires_at: null } : {}),
+      };
+      if (!Object.keys(body).length) usage('Provide at least one field to update.');
+      return emit(await client.request(`/api/urls/${pathPart(code)}`, { method: 'PATCH', body }), options);
+    }
+    case 'enable':
+    case 'disable':
+      return emit(await client.request(`/api/urls/${pathPart(code)}`, {
+        method: 'PATCH', body: { is_active: action === 'enable' },
+      }), options);
+    case 'delete':
+      requireConfirmation(options, `Deleting ${required(code, 'Usage: lixrl urls delete <code> --yes')}`);
+      return emit(await client.request(`/api/urls/${pathPart(code)}`, { method: 'DELETE' }), options);
+    case 'bulk-create': { // JSON array or {"links": [...]}
+      const file = required(options.file, 'Usage: lixrl urls bulk-create --file <links.json>');
+      const input = JSON.parse(await readFile(file, 'utf8'));
+      const links = Array.isArray(input) ? input : input.links;
+      if (!Array.isArray(links)) usage('Bulk input must be an array or an object containing a links array.');
+      return emit(await client.request('/api/urls/bulk-create', { method: 'POST', body: { links } }), options);
+    }
+    case 'bulk-delete':
+      requireConfirmation(options, 'Bulk deletion');
+      if (!args.length) usage('Usage: lixrl urls bulk-delete <code...> --yes');
+      return emit(await client.request('/api/urls/bulk-delete', { method: 'POST', body: { codes: args } }), options);
+    case 'analytics':
+      return emit(await client.request(query(`/api/urls/${pathPart(code)}/analytics`, { days: positive(options.days, 7) })), options);
+    case 'export': {
+      const response = await client.request('/api/urls/export.csv', { raw: true });
+      return writeResponse(response, options.output, options);
+    }
+    case 'export-clicks': {
+      const response = await client.request(`/api/urls/${pathPart(code)}/clicks.csv`, { raw: true });
+      return writeResponse(response, options.output, options);
+    }
+    default:
+      usage('Usage: lixrl urls <list|get|create|update|enable|disable|delete|bulk-create|bulk-delete|analytics|export|export-clicks>');
+  }
+}
+
+export async function runKeys(client, action, args, options) {
+  switch (action) {
+    case 'list':
+      return emit(await client.request('/api/keys'), options);
+    case 'create':
+      return emit(await client.request('/api/keys', {
+        method: 'POST',
+        body: {
+          name: required(options.name, 'Usage: lixrl keys create --name <name> [--scopes read|read,write]'),
+          scopes: options.scopes || 'read,write',
+          ...(options.expires ? { expires_at: options.expires } : {}),
+        },
+      }), options);
+    case 'revoke':
+      requireConfirmation(options, 'Revoking an API key');
+      return emit(await client.request(`/api/keys/${pathPart(args[0])}`, { method: 'DELETE' }), options);
+    default:
+      usage('Usage: lixrl keys <list|create|revoke>');
+  }
+}
+
+export async function runDomains(client, action, args, options) {
+  const id = args[0];
+  switch (action) {
+    case 'list':
+      return emit(await client.request('/api/subdomains'), options);
+    case 'claim':
+      return emit(await client.request('/api/subdomains', {
+        method: 'POST', body: { label: required(id, 'Usage: lixrl domains claim <label>') },
+      }), options);
+    case 'verify':
+      return emit(await client.request(`/api/subdomains/${pathPart(id)}/verify`, { method: 'POST', body: {} }), options);
+    case 'default':
+      return emit(await client.request(`/api/subdomains/${pathPart(id)}`, { method: 'PATCH', body: { is_default: true } }), options);
+    case 'remove':
+      requireConfirmation(options, 'Removing a subdomain');
+      return emit(await client.request(`/api/subdomains/${pathPart(id)}`, { method: 'DELETE' }), options);
+    case 'links':
+      return emit(await client.request(`/api/subdomains/${pathPart(id)}/links`), options);
+    case 'map':
+      return emit(await client.request(`/api/subdomains/${pathPart(id)}/links`, {
+        method: 'POST',
+        body: {
+          url_code: required(args[1], 'Usage: lixrl domains map <id> <url-code> [--slug <branded-code>]'),
+          ...(options.slug ? { short_code: options.slug } : {}),
+        },
+      }), options);
+    case 'unmap':
+      requireConfirmation(options, 'Removing a subdomain link mapping');
+      return emit(await client.request(`/api/subdomains/${pathPart(id)}/links/${pathPart(args[1])}`, { method: 'DELETE' }), options);
+    default:
+      usage('Usage: lixrl domains <list|claim|verify|default|remove|links|map|unmap>');
+  }
+}

--- a/packages/lixrl-cli/tests/operations.test.mjs
+++ b/packages/lixrl-cli/tests/operations.test.mjs
@@ -1,0 +1,41 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, readFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { runDomains, runKeys, runUrls } from '../src/commands.js';
+
+function recorder(result = { success: true }) {
+  const calls = [];
+  return {
+    calls,
+    client: { request: async (...args) => { calls.push(args); return result; } },
+  };
+}
+
+test('URL creation maps CLI flags to the production API schema', async () => {
+  const { client, calls } = recorder({ short_code: 'launch' });
+  await runUrls(client, 'create', ['https://example.com'], {
+    quiet: true, slug: 'launch', title: 'Launch', campaign: 'summer', tag: ['news'], 'utm-source': 'cli',
+  });
+  assert.deepEqual(calls[0], ['/api/urls', { method: 'POST', body: {
+    url: 'https://example.com', custom_code: 'launch', title: 'Launch', campaign: 'summer', tags: ['news'], utm: { source: 'cli' },
+  } }]);
+});
+
+test('destructive operations require explicit confirmation', async () => {
+  const { client } = recorder();
+  await assert.rejects(() => runUrls(client, 'delete', ['abc123'], { quiet: true }), /--yes/);
+  await assert.rejects(() => runKeys(client, 'revoke', ['1'], { quiet: true }), /--yes/);
+  await assert.rejects(() => runDomains(client, 'remove', ['1'], { quiet: true }), /--yes/);
+});
+
+test('bulk creation accepts a top-level JSON array', async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), 'lixrl-bulk-'));
+  const file = path.join(root, 'links.json');
+  await import('node:fs/promises').then(({ writeFile }) => writeFile(file, JSON.stringify([{ url: 'https://example.com' }])));
+  const { client, calls } = recorder();
+  await runUrls(client, 'bulk-create', [], { quiet: true, file });
+  assert.deepEqual(calls[0][1].body.links, [{ url: 'https://example.com' }]);
+  assert.match(await readFile(file, 'utf8'), /example/);
+});


### PR DESCRIPTION
## What this does
Adds production CLI commands for links, analytics, API keys, CSV exports, bulk actions, and paid subdomains. Commands map directly to the deployed Lixrl API.

## Why
Users and automation need the same management surface available in the dashboard.

## Changes
- create, inspect, search, update, enable, disable, and delete links
- bulk create/delete plus link and click CSV exports
- analytics retrieval with configurable retention window
- API-key listing, creation, and revocation
- subdomain claim, verification, default selection, mapping, and removal
- explicit confirmation for destructive actions and overwrites

## Verification
- `npm test --prefix packages/lixrl-cli` passes
- `git diff --check` clean

---
Fixes #48