### PR TITLE
[ELIXPO] Add QR exports and bundled CLI skills

### DIFF
--- a/.github/workflows/lixrl-cli-release-gate.yml
+++ b/.github/workflows/lixrl-cli-release-gate.yml
@@ -1,0 +1,48 @@
+name: Lixrl CLI release gate
+
+on:
+  workflow_call:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  packed-cli:
+    name: Packed artifact
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: packages/lixrl-cli/package-lock.json
+      - name: Install and test CLI
+        working-directory: packages/lixrl-cli
+        run: |
+          npm ci
+          npm test
+      - name: Pack release artifact
+        id: pack
+        working-directory: packages/lixrl-cli
+        run: |
+          mkdir -p ../../dist
+          TARBALL=$(npm pack --silent | tail -n 1)
+          test -n "$TARBALL"
+          mv "$TARBALL" ../../dist/
+          echo "tarball=$TARBALL" >> "$GITHUB_OUTPUT"
+      - name: Smoke-test packed CLI
+        run: |
+          TARBALL="dist/${{ steps.pack.outputs.tarball }}"
+          npm install --prefix "$RUNNER_TEMP/lixrl-smoke" "$TARBALL"
+          CLI="$RUNNER_TEMP/lixrl-smoke/node_modules/.bin/lixrl"
+          "$CLI" --help
+          "$CLI" skills list --json --no-input
+          "$CLI" qr https://lixrl.com --output "$RUNNER_TEMP/lixrl-smoke/qr.svg" --quiet
+          test -s "$RUNNER_TEMP/lixrl-smoke/qr.svg"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: lixrl-cli-package
+          path: dist/*.tgz
+          if-no-files-found: error

--- a/.github/workflows/publish-lixrl-cli.yml
+++ b/.github/workflows/publish-lixrl-cli.yml
@@ -1,0 +1,60 @@
+name: Publish @elixpo/lixrl-cli
+
+on:
+  push:
+    tags:
+      - 'lixrl-cli-v*'
+  workflow_dispatch:
+    inputs:
+      publish:
+        description: Publish the current package after the release gate
+        required: true
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+  id-token: write
+  attestations: write
+
+jobs:
+  gate:
+    uses: ./.github/workflows/lixrl-cli-release-gate.yml
+
+  publish:
+    name: Publish signed package
+    needs: gate
+    if: github.ref_type == 'tag' || inputs.publish == true
+    runs-on: ubuntu-latest
+    environment: npm
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: https://registry.npmjs.org
+      - uses: actions/download-artifact@v4
+        with:
+          name: lixrl-cli-package
+          path: dist
+      - name: Verify tag and package versions
+        if: github.ref_type == 'tag'
+        run: |
+          PACKAGE_VERSION=$(node -p "require('./packages/lixrl-cli/package.json').version")
+          test "$GITHUB_REF_NAME" = "lixrl-cli-v${PACKAGE_VERSION}"
+      - name: Attest package provenance
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: dist/*.tgz
+      - name: Publish to npm with provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish dist/*.tgz --access public --provenance
+      - name: Publish GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: >-
+          gh release create "lixrl-cli-v$(node -p "require('./packages/lixrl-cli/package.json').version")"
+          dist/*.tgz
+          --generate-notes
+          --title "@elixpo/lixrl-cli $(node -p "require('./packages/lixrl-cli/package.json').version")"

--- a/.github/workflows/publish-lixrl-cli.yml
+++ b/.github/workflows/publish-lixrl-cli.yml
@@ -26,7 +26,7 @@ jobs:
     needs: gate
     if: github.ref_type == 'tag' || inputs.publish == true
     runs-on: ubuntu-latest
-    environment: npm
+    environment: production
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,16 +1,28 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-PROJECT="elixpourl"
-OUTDIR=".vercel/output/static"
-WRANGLER_CONFIG="$SCRIPT_DIR/wrangler.toml"
-SUBDOMAIN_WRANGLER_CONFIG="$SCRIPT_DIR/wrangler.subdomains.toml"
+# Lixrl deploy and release utility.
+#
+# Target syntax:
+#   ./deploy.sh --package build deploy [--no-bump|--patch|--minor|--major]
+#   ./deploy.sh --worker build deploy
+#   ./deploy.sh --pages build deploy
+#   ./deploy.sh --github build deploy
+#
+# Legacy syntax remains available:
+#   ./deploy.sh migrate build deploy
+#   ./deploy.sh secrets deploy
+#   ./deploy.sh all
 
-# CF Pages treats `main` as Production. Without --branch, wrangler tags the
-# deploy as Preview for whatever git branch you're on — which never updates
-# lixrl.com. Override with DEPLOY_BRANCH=<branch> for a preview from CLI.
-BRANCH="${DEPLOY_BRANCH:-main}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PAGES_PROJECT="elixpourl"
+PAGES_OUTDIR="$SCRIPT_DIR/.vercel/output/static"
+PAGES_BRANCH="${DEPLOY_BRANCH:-main}"
+WRANGLER_CONFIG="$SCRIPT_DIR/wrangler.toml"
+SUBDOMAIN_CONFIG="$SCRIPT_DIR/wrangler.subdomains.toml"
+CLI_DIR="$SCRIPT_DIR/packages/lixrl-cli"
+CLI_PACKAGE="@elixpo/lixrl-cli"
+PUBLISH_WORKFLOW="publish-lixrl-cli.yml"
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -18,263 +30,316 @@ DIM='\033[2m'
 BOLD='\033[1m'
 RESET='\033[0m'
 
+DRY_RUN=false
+BUMP="patch"
+NO_BUMP=false
+
+log() { echo -e "${GREEN}▸${RESET} $1"; }
+dim() { echo -e "${DIM}  $1${RESET}"; }
+err() { echo -e "${RED}✗${RESET} $1" >&2; }
+
 usage() {
-  echo -e "${BOLD}Usage:${RESET} ./deploy.sh <command> [command...]"
+  echo -e "${BOLD}Usage:${RESET} ./deploy.sh TARGET PHASE... [options]"
   echo ""
-  echo "Commands (can be chained):"
-  echo "  build     Build the Next.js app with @cloudflare/next-on-pages"
-  echo "  deploy    Deploy to Cloudflare Pages (builds first if needed)"
-  echo "            Production also deploys the *.lixrl.com redirect Worker"
-  echo "  all       Build and deploy in one step"
-  echo "  migrate   Run D1 database migrations (remote)"
-  echo "  secrets   Decrypt .env (sops) and upload all secrets to Pages prod"
+  echo "Targets:"
+  echo "  --package           $CLI_PACKAGE on npm"
+  echo "  --worker            *.lixrl.com redirect Worker"
+  echo "  --pages             Lixrl Cloudflare Pages site"
+  echo "  --github            CLI GitHub release/package artifact"
+  echo ""
+  echo "Phases:"
+  echo "  build               Build, test, or package the target"
+  echo "  deploy              Deploy or publish the target"
+  echo ""
+  echo "Options:"
+  echo "  --patch             Patch package version bump (default)"
+  echo "  --minor             Minor package version bump"
+  echo "  --major             Major package version bump"
+  echo "  --no-bump           Keep the package version (use for v1.0.1)"
+  echo "  --dry-run           Print actions without executing them"
   echo ""
   echo "Examples:"
-  echo "  ./deploy.sh build deploy"
+  echo "  ./deploy.sh --package build --no-bump"
+  echo "  ./deploy.sh --package deploy --no-bump"
+  echo "  ./deploy.sh --worker build deploy"
+  echo "  ./deploy.sh --pages build deploy"
   echo "  ./deploy.sh migrate build deploy"
-  echo "  ./deploy.sh secrets deploy   # push env secrets, then redeploy"
+  echo "  DEPLOY_BRANCH=feat/demo ./deploy.sh --pages deploy"
   echo ""
-  echo -e "${DIM}Override the deploy branch:${RESET}"
-  echo "  DEPLOY_BRANCH=elixpo/feat-x ./deploy.sh deploy   # preview from a feature branch"
-  exit 1
+  echo "Legacy commands: build, deploy, all, migrate, secrets"
 }
 
-log()  { echo -e "${GREEN}▸${RESET} $1"; }
-dim()  { echo -e "${DIM}  $1${RESET}"; }
-err()  { echo -e "${RED}✗${RESET} $1" >&2; }
-
-# Refuse to run as root. `sudo npx` was the previous footgun: it left
-# .vercel/, node_modules/, and .next/ owned by root, which then broke every
-# subsequent non-sudo command in the repo until the user manually chowned
-# their working tree back. We require ownership of these dirs already, not
-# sudo escalation.
 check_not_root() {
   if [ "$(id -u)" = "0" ]; then
     err "Refusing to run as root. Run as your normal user."
-    err "If npx fails with EACCES, fix node_modules ownership instead:"
-    err "  sudo chown -R \"\$(id -u):\$(id -g)\" node_modules .next .vercel"
     exit 1
   fi
 }
 
-check_deps() {
-  for cmd in npx node; do
-    if ! command -v "$cmd" &>/dev/null; then
-      err "$cmd is required but not found"
+check_layout() {
+  for file in "$WRANGLER_CONFIG" "$SUBDOMAIN_CONFIG" "$CLI_DIR/package.json"; do
+    if [ ! -f "$file" ]; then
+      err "Required file not found: $file"
       exit 1
     fi
   done
+}
 
-  if [ ! -f "$WRANGLER_CONFIG" ]; then
-    err "Wrangler config not found: $WRANGLER_CONFIG"
-    exit 1
-  fi
-  if [ ! -f "$SUBDOMAIN_WRANGLER_CONFIG" ]; then
-    err "Subdomain Wrangler config not found: $SUBDOMAIN_WRANGLER_CONFIG"
-    exit 1
+run_in_dir() {
+  local directory="$1"
+  shift
+  if $DRY_RUN; then
+    printf '[dry-run] cd %q &&' "$directory"
+    printf ' %q' "$@"
+    printf '\n'
+  else
+    (cd "$directory" && "$@")
   fi
 }
 
-# Wrangler automatically reads .env, but this repository stores that file in
-# SOPS-encrypted form. Export the decrypted deploy credentials first so
-# Wrangler does not mistake an ENC[...] value for an API token. An explicitly
-# supplied plaintext token (for example in CI) still takes precedence.
+cli_version() {
+  sed -n 's/^[[:space:]]*"version":[[:space:]]*"\([^"]*\)".*/\1/p' "$CLI_DIR/package.json" | head -1
+}
+
 load_cloudflare_auth() {
-  if [ -n "${CLOUDFLARE_API_TOKEN:-}" ] &&
-     [[ "$CLOUDFLARE_API_TOKEN" != ENC\[* ]]; then
+  if [ -n "${CLOUDFLARE_API_TOKEN:-}" ] && [[ "$CLOUDFLARE_API_TOKEN" != ENC\[* ]]; then
     return
   fi
-
-  if ! command -v sops &>/dev/null; then
+  if ! command -v sops >/dev/null 2>&1; then
     err "sops is required to decrypt Cloudflare credentials from .env"
     exit 1
   fi
-
-  local enc="$SCRIPT_DIR/.env"
-  if [ ! -f "$enc" ]; then
+  local encrypted="$SCRIPT_DIR/.env"
+  if [ ! -f "$encrypted" ]; then
     err ".env (sops-encrypted) not found"
     exit 1
   fi
-
   if [ -z "${SOPS_AGE_KEY:-}" ]; then
     local keyfile="$HOME/.config/sops/age/keys.txt"
-    if [ -f "$keyfile" ]; then
-      SOPS_AGE_KEY="$(grep 'AGE-SECRET-KEY' "$keyfile" | head -1)"
-      export SOPS_AGE_KEY
-    else
+    if [ ! -f "$keyfile" ]; then
       err "No AGE key. Set SOPS_AGE_KEY or create $keyfile"
       exit 1
     fi
+    SOPS_AGE_KEY="$(grep 'AGE-SECRET-KEY' "$keyfile" | head -1)"
+    export SOPS_AGE_KEY
   fi
 
   local decrypted token="" account_id=""
-  decrypted="$(sops decrypt "$enc")"
+  decrypted="$(sops decrypt "$encrypted")"
   while IFS= read -r line || [ -n "$line" ]; do
     case "$line" in
       CLOUDFLARE_API_TOKEN=*) token="${line#*=}" ;;
       CLOUDFLARE_ACCOUNT_ID=*) account_id="${line#*=}" ;;
     esac
   done <<< "$decrypted"
-
   if [ -z "$token" ]; then
     err "CLOUDFLARE_API_TOKEN not found in decrypted .env"
     exit 1
   fi
-
   export CLOUDFLARE_API_TOKEN="$token"
   if [ -n "$account_id" ]; then
     export CLOUDFLARE_ACCOUNT_ID="$account_id"
   fi
 }
 
-do_build() {
-  log "Building ${BOLD}$PROJECT${RESET} with @cloudflare/next-on-pages..."
-  npx @cloudflare/next-on-pages
-  log "Build complete → ${DIM}$OUTDIR${RESET}"
+pages_build() {
+  log "Building ${BOLD}$PAGES_PROJECT${RESET} with @cloudflare/next-on-pages..."
+  run_in_dir "$SCRIPT_DIR" npm run pages:build
 }
 
-do_deploy() {
-  if [ ! -d "$OUTDIR" ]; then
-    log "No build output found, building first..."
-    do_build
+pages_deploy() {
+  if ! $DRY_RUN && [ ! -d "$PAGES_OUTDIR" ]; then
+    err "Pages output is missing. Run './deploy.sh --pages build deploy'."
+    exit 1
   fi
-  log "Deploying to ${BOLD}Cloudflare Pages${RESET} on branch ${BOLD}$BRANCH${RESET}..."
-  if [ "$BRANCH" = "main" ]; then
-    dim "Production deploy — will update lixrl.com on success."
+  if ! $DRY_RUN; then load_cloudflare_auth; fi
+  log "Deploying Pages project ${BOLD}$PAGES_PROJECT${RESET} on ${BOLD}$PAGES_BRANCH${RESET}..."
+  # Running at the repository root makes Wrangler load wrangler.toml.
+  run_in_dir "$SCRIPT_DIR" npx wrangler pages deploy .vercel/output/static \
+    --project-name "$PAGES_PROJECT" --branch "$PAGES_BRANCH"
+}
+
+worker_build() {
+  log "Validating the ${BOLD}*.lixrl.com${RESET} Worker bundle..."
+  run_in_dir "$SCRIPT_DIR" npx wrangler deploy --config "$SUBDOMAIN_CONFIG" \
+    --dry-run --outdir .wrangler/deploy/subdomains
+}
+
+worker_deploy() {
+  if ! $DRY_RUN; then load_cloudflare_auth; fi
+  log "Deploying the ${BOLD}*.lixrl.com${RESET} redirect Worker..."
+  run_in_dir "$SCRIPT_DIR" npx wrangler deploy --config "$SUBDOMAIN_CONFIG"
+}
+
+package_bump() {
+  if $NO_BUMP; then
+    dim "Keeping $CLI_PACKAGE at $(cli_version)."
+    return
+  fi
+  log "Bumping $CLI_PACKAGE ($BUMP)..."
+  run_in_dir "$CLI_DIR" npm version "$BUMP" --no-git-tag-version
+}
+
+package_build() {
+  log "Installing and testing ${BOLD}$CLI_PACKAGE${RESET}..."
+  run_in_dir "$CLI_DIR" npm ci
+  run_in_dir "$CLI_DIR" npm test
+  run_in_dir "$CLI_DIR" npm pack --dry-run
+}
+
+package_deploy() {
+  if ! command -v gh >/dev/null 2>&1; then
+    err "gh is required to start the protected npm release workflow"
+    exit 1
+  fi
+  if ! $NO_BUMP; then
+    err "Commit and merge the bumped CLI version, then rerun deploy with --no-bump."
+    exit 1
+  fi
+  local version
+  version="$(cli_version)"
+  log "Dispatching ${BOLD}$CLI_PACKAGE@$version${RESET} through GitHub's production environment..."
+  if $DRY_RUN; then
+    echo "[dry-run] gh workflow run $PUBLISH_WORKFLOW --ref main -f publish=true"
   else
-    dim "Preview deploy — production URL stays on whatever's deployed to main."
+    gh workflow run "$PUBLISH_WORKFLOW" --ref main -f publish=true
   fi
-  load_cloudflare_auth
-  # Pages only accepts the default wrangler.toml path. Run from the project
-  # root so Wrangler discovers that config implicitly; an explicit --config
-  # fails even when it resolves to this same file.
-  (
-    cd "$SCRIPT_DIR"
-    npx wrangler pages deploy "$OUTDIR" \
-      --project-name="$PROJECT" \
-      --branch="$BRANCH"
-  )
-  if [ "$BRANCH" = "main" ]; then
-    log "Deploying the ${BOLD}*.lixrl.com${RESET} redirect Worker..."
-    npx wrangler deploy --config="$SUBDOMAIN_WRANGLER_CONFIG"
-  else
-    dim "Skipping wildcard subdomain Worker for preview branch."
-  fi
-  log "Deploy complete"
+  dim "The release gate will test, pack, attest, publish to npm, and create the GitHub release."
 }
 
 do_migrate() {
-  log "Running D1 migrations (remote) for ${BOLD}$PROJECT${RESET}..."
   load_cloudflare_auth
-  npx wrangler d1 migrations apply "$PROJECT" \
-    --config="$WRANGLER_CONFIG" \
-    --remote
-  log "Migrations applied"
+  log "Applying remote D1 migrations with ${BOLD}wrangler.toml${RESET}..."
+  run_in_dir "$SCRIPT_DIR" npx wrangler d1 migrations apply "$PAGES_PROJECT" \
+    --config "$WRANGLER_CONFIG" --remote
 }
 
-# Decrypt the sops-managed .env and push every secret to the Pages project's
-# production environment. Mirrors sops-reencrypt.sh's AGE-key resolution, but
-# decrypts in memory (never writes plaintext to disk, never touches the
-# working .env.local). CLOUDFLARE_* are deploy-time creds — used to auth
-# wrangler, not pushed to the app runtime.
 do_secrets() {
-  if ! command -v sops &>/dev/null; then
-    err "sops is required for the secrets command but was not found"
+  if ! command -v sops >/dev/null 2>&1; then
+    err "sops is required for the secrets command"
     exit 1
   fi
-
-  local enc="$SCRIPT_DIR/.env"
-  if [ ! -f "$enc" ]; then
-    err ".env (sops-encrypted) not found. Run ./sops-reencrypt.sh first."
+  local encrypted="$SCRIPT_DIR/.env"
+  if [ ! -f "$encrypted" ]; then
+    err ".env (sops-encrypted) not found"
     exit 1
   fi
+  load_cloudflare_auth
 
-  # Same key resolution as sops-reencrypt.sh.
-  if [ -z "${SOPS_AGE_KEY:-}" ]; then
-    local keyfile="$HOME/.config/sops/age/keys.txt"
-    if [ -f "$keyfile" ]; then
-      SOPS_AGE_KEY="$(grep 'AGE-SECRET-KEY' "$keyfile" | head -1)"
-      export SOPS_AGE_KEY
-    else
-      err "No AGE key. Set SOPS_AGE_KEY or create $keyfile"
-      exit 1
-    fi
-  fi
-
-  log "Decrypting ${BOLD}.env${RESET} with sops (in memory)..."
   local decrypted
-  decrypted="$(sops decrypt "$enc")"
-
-  # Parse KEY=VALUE into a map (skip blanks, comments, non-identifier keys).
+  decrypted="$(sops decrypt "$encrypted")"
   declare -A vars=()
   while IFS= read -r line || [ -n "$line" ]; do
     [[ -z "$line" || "$line" == \#* || "$line" != *=* ]] && continue
-    local k="${line%%=*}" v="${line#*=}"
-    [[ "$k" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || continue
-    vars["$k"]="$v"
+    local key="${line%%=*}" value="${line#*=}"
+    [[ "$key" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || continue
+    vars["$key"]="$value"
   done <<< "$decrypted"
 
-  # Auth wrangler with the CF creds pulled from the vault.
-  export CLOUDFLARE_API_TOKEN="${vars[CLOUDFLARE_API_TOKEN]:-${CLOUDFLARE_API_TOKEN:-}}"
-  export CLOUDFLARE_ACCOUNT_ID="${vars[CLOUDFLARE_ACCOUNT_ID]:-${CLOUDFLARE_ACCOUNT_ID:-}}"
-  if [ -z "$CLOUDFLARE_API_TOKEN" ]; then
-    err "CLOUDFLARE_API_TOKEN not found in .env (needed to authenticate wrangler)"
-    exit 1
-  fi
-
-  log "Uploading secrets to ${BOLD}$PROJECT${RESET} (production)..."
-  local count=0
-  for k in "${!vars[@]}"; do
-    case "$k" in
-      CLOUDFLARE_API_TOKEN | CLOUDFLARE_ACCOUNT_ID)
-        dim "skip $k (deploy-time credential, not app runtime)"
-        continue
-        ;;
-      DEV_TIER_OVERRIDE)
-        # Dev-only: would promote EVERY prod user to that tier. Never ship it.
-        dim "skip $k (dev-only — must not reach production)"
-        continue
-        ;;
-      BASE_URL)
-        # Environment-specific (vault holds the localhost dev value). Set the
-        # prod origin directly on the Pages project, e.g. https://lixrl.com.
-        dim "skip $k (env-specific — set prod origin on Pages directly)"
+  local count=0 key
+  log "Uploading runtime secrets to ${BOLD}$PAGES_PROJECT${RESET}..."
+  for key in "${!vars[@]}"; do
+    case "$key" in
+      CLOUDFLARE_API_TOKEN|CLOUDFLARE_ACCOUNT_ID|DEV_TIER_OVERRIDE|BASE_URL)
+        dim "skip $key"
         continue
         ;;
     esac
-    printf '%s' "${vars[$k]}" | npx wrangler pages secret put "$k" \
-      --config="$WRANGLER_CONFIG" \
-      --project-name="$PROJECT" >/dev/null
-    dim "set $k"
+    if $DRY_RUN; then
+      echo "[dry-run] wrangler pages secret put $key --project-name $PAGES_PROJECT"
+    else
+      printf '%s' "${vars[$key]}" | npx wrangler pages secret put "$key" \
+        --config "$WRANGLER_CONFIG" --project-name "$PAGES_PROJECT" >/dev/null
+    fi
+    dim "set $key"
     count=$((count + 1))
   done
-  if [ -n "${vars[GUEST_FINGERPRINT_SECRET]:-}" ]; then
-    printf '%s' "${vars[GUEST_FINGERPRINT_SECRET]}" | npx wrangler secret put \
-      GUEST_FINGERPRINT_SECRET --config="$SUBDOMAIN_WRANGLER_CONFIG" >/dev/null
-    dim "set GUEST_FINGERPRINT_SECRET on lixrl-subdomain-router"
-  fi
-  log "Uploaded $count secrets"
-  dim "Secrets apply to the next deploy — run: ./deploy.sh deploy"
+  log "Uploaded $count Pages secrets."
 }
 
-run_cmd() {
+run_target_standard() {
+  local target="" action_build=false action_deploy=false
+  BUMP="patch"
+  NO_BUMP=false
+  DRY_RUN=false
+
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --package|--worker|--pages|--github)
+        if [ -n "$target" ]; then
+          err "Choose exactly one deployment target."
+          exit 1
+        fi
+        target="${1#--}"
+        ;;
+      build) action_build=true ;;
+      deploy) action_deploy=true ;;
+      --patch) BUMP="patch" ;;
+      --minor) BUMP="minor" ;;
+      --major) BUMP="major" ;;
+      --no-bump) NO_BUMP=true ;;
+      --dry-run) DRY_RUN=true ;;
+      -h|--help|help) usage; return ;;
+      *) err "Unknown argument: $1"; usage; exit 1 ;;
+    esac
+    shift
+  done
+
+  if [ -z "$target" ] || { ! $action_build && ! $action_deploy; }; then
+    err "Choose one target and at least one build or deploy phase."
+    usage
+    exit 1
+  fi
+
+  case "$target" in
+    package|github)
+      package_bump
+      if $action_build; then package_build; fi
+      if $action_deploy; then package_deploy; fi
+      ;;
+    worker)
+      if $action_build; then worker_build; fi
+      if $action_deploy; then worker_deploy; fi
+      ;;
+    pages)
+      if $action_build; then pages_build; fi
+      if $action_deploy; then pages_deploy; fi
+      ;;
+  esac
+}
+
+run_legacy_command() {
   case "$1" in
-    build)   do_build ;;
-    deploy)  do_deploy ;;
-    all)     do_build && do_deploy ;;
+    build) pages_build ;;
+    deploy)
+      if [ ! -d "$PAGES_OUTDIR" ]; then pages_build; fi
+      pages_deploy
+      if [ "$PAGES_BRANCH" = "main" ]; then worker_deploy; fi
+      ;;
+    all)
+      pages_build
+      pages_deploy
+      if [ "$PAGES_BRANCH" = "main" ]; then worker_deploy; fi
+      ;;
     migrate) do_migrate ;;
     secrets) do_secrets ;;
-    *)       err "Unknown command: $1"; usage ;;
+    -h|--help|help) usage ;;
+    *) err "Unknown command: $1"; usage; exit 1 ;;
   esac
 }
 
 check_not_root
-check_deps
+check_layout
 
 if [ $# -eq 0 ]; then
   usage
+  exit 1
 fi
 
-for cmd in "$@"; do
-  run_cmd "$cmd"
-done
+if [[ "$1" =~ ^--(package|worker|pages|github)$ ]]; then
+  run_target_standard "$@"
+else
+  for command in "$@"; do
+    run_legacy_command "$command"
+  done
+fi

--- a/packages/lixrl-cli/README.md
+++ b/packages/lixrl-cli/README.md
@@ -21,6 +21,21 @@ lixrl urls analytics abc123 --days 30
 lixrl urls export --output links.csv
 lixrl keys create --name deploy --scopes read,write
 lixrl domains claim team
+lixrl qr https://example.com --format png --style rounded --output launch.png
+lixrl qr https://example.com --track --style aurora --output campaign.svg
 ```
 
 Deletion, API-key revocation, mapping removal, and file replacement require `--yes`. Use `--json --no-input` for automation.
+
+## Agent skills
+
+The npm package contains focused skills for link management and QR generation. They are not copied anywhere during installation.
+
+```bash
+lixrl skills list
+lixrl skills inspect lixrl-links
+lixrl skills install lixrl-links
+lixrl skills install lixrl-qr
+```
+
+`skills install` copies the selected skill into the current Codex skills directory. This keeps the skill version tied to the installed CLI release.

--- a/packages/lixrl-cli/RELEASE.md
+++ b/packages/lixrl-cli/RELEASE.md
@@ -3,6 +3,6 @@
 1. Merge the three CLI PRs in stack order.
 2. Run `npm ci` and `npm test` in `packages/lixrl-cli`.
 3. Run `npm pack --dry-run` and inspect the included files.
-4. Confirm `npm whoami` uses the Elixpo publishing account.
-5. Publish with `npm publish --access public` from `packages/lixrl-cli`.
+4. Configure `NPM_TOKEN` in the protected GitHub `npm` environment.
+5. Tag merged `main` as `lixrl-cli-v1.0.1`, or dispatch the publish workflow on merged `main`.
 6. Verify `npm view @elixpo/lixrl-cli@1.0.1 version dist.integrity`.

--- a/packages/lixrl-cli/RELEASE.md
+++ b/packages/lixrl-cli/RELEASE.md
@@ -1,0 +1,8 @@
+# Release 1.0.1
+
+1. Merge the three CLI PRs in stack order.
+2. Run `npm ci` and `npm test` in `packages/lixrl-cli`.
+3. Run `npm pack --dry-run` and inspect the included files.
+4. Confirm `npm whoami` uses the Elixpo publishing account.
+5. Publish with `npm publish --access public` from `packages/lixrl-cli`.
+6. Verify `npm view @elixpo/lixrl-cli@1.0.1 version dist.integrity`.

--- a/packages/lixrl-cli/RELEASE.md
+++ b/packages/lixrl-cli/RELEASE.md
@@ -3,6 +3,6 @@
 1. Merge the three CLI PRs in stack order.
 2. Run `npm ci` and `npm test` in `packages/lixrl-cli`.
 3. Run `npm pack --dry-run` and inspect the included files.
-4. Configure `NPM_TOKEN` in the protected GitHub `npm` environment.
+4. Configure `NPM_TOKEN` in the protected GitHub `production` environment.
 5. Tag merged `main` as `lixrl-cli-v1.0.1`, or dispatch the publish workflow on merged `main`.
 6. Verify `npm view @elixpo/lixrl-cli@1.0.1 version dist.integrity`.

--- a/packages/lixrl-cli/THREAT_MODEL.md
+++ b/packages/lixrl-cli/THREAT_MODEL.md
@@ -1,0 +1,8 @@
+# Security model
+
+- Interactive API keys are stored by the operating-system keychain, never in the CLI config file.
+- Automation reads `LIXRL_API_KEY` from the current process environment.
+- API requests are restricted to `/api/*` on the configured HTTPS origin.
+- JSON and error output redact credential-shaped fields.
+- Destructive actions and file replacement require explicit confirmation.
+- Bundled skills call the CLI and do not access credentials directly.

--- a/packages/lixrl-cli/bin/shortner.mjs
+++ b/packages/lixrl-cli/bin/shortner.mjs
@@ -7,6 +7,8 @@ import { LixrlClient } from '../src/client.js';
 import { emit, fail, EXIT_CODES } from '../src/contract.js';
 import { openBrowser, promptSecret } from '../src/ui.js';
 import { runDomains, runKeys, runUrls } from '../src/commands.js';
+import { qrRequiresLogin, runQr } from '../src/qr.js';
+import { runSkills } from '../src/skills.js';
 
 const VERSION = '1.0.1';
 const OPTIONS = {
@@ -41,6 +43,12 @@ const OPTIONS = {
   output: { type: 'string', short: 'o' },
   name: { type: 'string' },
   scopes: { type: 'string' },
+  format: { type: 'string' },
+  style: { type: 'string' },
+  size: { type: 'string' },
+  logo: { type: 'string' },
+  track: { type: 'boolean', default: false },
+  target: { type: 'string' },
   help: { type: 'boolean', short: 'h', default: false },
   version: { type: 'boolean', short: 'v', default: false },
 };
@@ -63,6 +71,9 @@ Usage:
   lixrl urls export-clicks <code> [--output <file.csv>]
   lixrl keys list|create|revoke
   lixrl domains list|claim|verify|default|remove|links|map|unmap
+  lixrl qr <destination> [--format svg|png|jpg] [--style rounded]
+  lixrl qr <destination> --track [--title <title>]
+  lixrl skills list|inspect|install [name]
 
 Authentication:
   Create a read/write API key at https://lixrl.com/profile/keys. Login stores it
@@ -112,6 +123,11 @@ async function main(argv = process.argv.slice(2)) {
     await registry.use(subcommand);
     return emit({ active: subcommand }, options);
   }
+  if (command === 'skills') return runSkills(subcommand, args, options);
+
+  if (command === 'qr' && !qrRequiresLogin(options)) {
+    return runQr(null, subcommand, options);
+  }
 
   const key = await credentials.get(profile);
   if (!key) throw Object.assign(new Error(`Profile "${profile}" is not logged in. Run lixrl login.`), { code: 'login_required', exitCode: EXIT_CODES.AUTH });
@@ -127,6 +143,7 @@ async function main(argv = process.argv.slice(2)) {
     return emit({ profile, ...user }, options);
   }
   const client = new LixrlClient({ apiUrl: config.apiUrl, apiKey: key });
+  if (command === 'qr') return runQr(client, subcommand, options);
   if (['url', 'urls', 'links'].includes(command)) return runUrls(client, subcommand, args, options);
   if (['key', 'keys'].includes(command)) return runKeys(client, subcommand, args, options);
   if (['domain', 'domains', 'subdomains'].includes(command)) return runDomains(client, subcommand, args, options);

--- a/packages/lixrl-cli/package-lock.json
+++ b/packages/lixrl-cli/package-lock.json
@@ -14,7 +14,10 @@
         "win32"
       ],
       "dependencies": {
-        "@napi-rs/keyring": "^1.3.0"
+        "@napi-rs/canvas": "^0.1.80",
+        "@napi-rs/keyring": "^1.3.0",
+        "jsdom": "^26.1.0",
+        "qr-code-styling": "^1.9.2"
       },
       "bin": {
         "lixrl": "bin/shortner.mjs",
@@ -22,6 +25,393 @@
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@napi-rs/canvas": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-0.1.100.tgz",
+      "integrity": "sha512-xglYA6q3XO5P3BNJYxVZ1IV7DLVjp1Py6nwag88YntrS+3vKHyYcMqXVS4ZztJmwz2uGvz1FWhI/4LgbR5uQDA==",
+      "license": "MIT",
+      "workspaces": [
+        "e2e/*"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas-android-arm64": "0.1.100",
+        "@napi-rs/canvas-darwin-arm64": "0.1.100",
+        "@napi-rs/canvas-darwin-x64": "0.1.100",
+        "@napi-rs/canvas-linux-arm-gnueabihf": "0.1.100",
+        "@napi-rs/canvas-linux-arm64-gnu": "0.1.100",
+        "@napi-rs/canvas-linux-arm64-musl": "0.1.100",
+        "@napi-rs/canvas-linux-riscv64-gnu": "0.1.100",
+        "@napi-rs/canvas-linux-x64-gnu": "0.1.100",
+        "@napi-rs/canvas-linux-x64-musl": "0.1.100",
+        "@napi-rs/canvas-win32-arm64-msvc": "0.1.100",
+        "@napi-rs/canvas-win32-x64-msvc": "0.1.100"
+      }
+    },
+    "node_modules/@napi-rs/canvas-android-arm64": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-0.1.100.tgz",
+      "integrity": "sha512-hjhCKhntPv9+t4ckHymdx0phYNcVW+GKQR6Lzw2zE+pOVjOplSmtx9nNNknTjbEDLcuLZqA1y8ufKg1XfgftzQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-arm64": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-0.1.100.tgz",
+      "integrity": "sha512-2PcswRaC7Ly645DGt88///zuFDhJxJYdKAs1uU3mfk1atYkXufgcgLfBpk6Tm12nCQBaNt1wpybuPZ4qOhTo8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-x64": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-0.1.100.tgz",
+      "integrity": "sha512-ePNZtj7pNIva/siZMg+HmbeozkIjqUIYdoymH8HaA3qK7LfzFN4WMBM8G6HQ9ZC+H3+Dnn5pqtiXpgLykaPOhw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm-gnueabihf": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-0.1.100.tgz",
+      "integrity": "sha512-d5cDB48oWFGU8/XPhUOFAlySgb/VAu7D+s8fi55K1Pcfg8aPplHWqMgibhVLU8ky7Pyg/fuiVLz4Nf3JrSTuUA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-gnu": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-0.1.100.tgz",
+      "integrity": "sha512-rDxgxRu69RvDlX/bh9o22DxLsGr8EqsNgotL9+RwQE1S0b0cqeatqsw6aW45mukm0B42DIAaAacKaYQ8cqS1nw==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-musl": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-0.1.100.tgz",
+      "integrity": "sha512-K3mDW66N+xT2/V439u1alFANiBUjdEx2gLiNYnCmUsva5jZMxWTjafBYwTzYK+EMFMHrUoabuU+T1BIP5CgbYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-riscv64-gnu": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-0.1.100.tgz",
+      "integrity": "sha512-mooqUBTIsccZpnoQC4NgrC1v6C1vof39etLNMnBwCY+p0gajWJvAHLGQ6g/gGyS5YrpDW+GefSN4+Cvcr08UWw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-gnu": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-0.1.100.tgz",
+      "integrity": "sha512-1eCvkDCazm7FFhsT7DfGOdSaHgZVK3bt/dSBl5EWHOWmnz+I7j8tPseJqqD81NF+MH21jKUK4wQSDjN0mdhnTg==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-musl": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-0.1.100.tgz",
+      "integrity": "sha512-20arT6lnI19S68qNlii73TSEDbECNgzMz2EpldC1V3mZFuRkeujXkcebRk0LRJe9SEUAooYiLokfMViY8IX7yA==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-arm64-msvc": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-arm64-msvc/-/canvas-win32-arm64-msvc-0.1.100.tgz",
+      "integrity": "sha512-DZFFT1wIAg37LJw37yhMRFfjATd3vTQzjZ1Yki8u2vhO6Hi5VE6BVaGQ1aaDu7xb4iMErz+9EOwjpS7xcxFeBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-x64-msvc": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-0.1.100.tgz",
+      "integrity": "sha512-MyT1j3mHC2+Lu4pBi9mKyMJhtP6U7k7EldY7sj/uS5gJA65gTXt8MefJQXLJo5d/vZbuWmfxzkEUNc/urV3pHA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
       }
     },
     "node_modules/@napi-rs/keyring": {
@@ -257,6 +647,392 @@
       "engines": {
         "node": ">= 10"
       }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
+      "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
+      "license": "MIT",
+      "dependencies": {
+        "cssstyle": "^4.2.1",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.5.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.16",
+        "parse5": "^7.2.1",
+        "rrweb-cssom": "^0.8.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^5.1.1",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.1.1",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/nwsapi": {
+      "version": "2.2.25",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.25.tgz",
+      "integrity": "sha512-kktSgNDIbyEIs/LrE6dtEMnfzxSDpXViFl6c4gFjz/CgtnL4GDCR3wyZXzjvAXsNB8dXU4dAfvIOgLMH2/vwLg==",
+      "license": "MIT"
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/qr-code-styling": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/qr-code-styling/-/qr-code-styling-1.9.2.tgz",
+      "integrity": "sha512-RgJaZJ1/RrXJ6N0j7a+pdw3zMBmzZU4VN2dtAZf8ZggCfRB5stEQ3IoDNGaNhYY3nnZKYlYSLl5YkfWN5dPutg==",
+      "license": "MIT",
+      "dependencies": {
+        "qrcode-generator": "^1.4.4"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/qrcode-generator": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/qrcode-generator/-/qrcode-generator-1.5.2.tgz",
+      "integrity": "sha512-pItrW0Z9HnDBnFmgiNrY1uxRdri32Uh9EjNYLPVC2zZ3ZRIIEqBoDgm4DkvDwNNDHTK7FNkmr8zAa77BYc9xNw==",
+      "license": "MIT"
+    },
+    "node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "license": "MIT"
+    },
+    "node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "license": "MIT"
     }
   }
 }

--- a/packages/lixrl-cli/package.json
+++ b/packages/lixrl-cli/package.json
@@ -31,7 +31,10 @@
     "node": ">=20"
   },
   "dependencies": {
-    "@napi-rs/keyring": "^1.3.0"
+    "@napi-rs/canvas": "^0.1.80",
+    "@napi-rs/keyring": "^1.3.0",
+    "jsdom": "^26.1.0",
+    "qr-code-styling": "^1.9.2"
   },
   "keywords": [
     "lixrl",

--- a/packages/lixrl-cli/skills/lixrl-links/SKILL.md
+++ b/packages/lixrl-cli/skills/lixrl-links/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: lixrl-links
+description: Manage Lixrl production short links through the installed lixrl CLI. Use when creating, listing, editing, disabling, deleting, exporting, or inspecting analytics for Lixrl links, or when managing Lixrl API keys and paid subdomains.
+---
+
+# Lixrl Links
+
+Use the installed `lixrl` executable. Do not read credential files or ask the user to paste an API key into chat.
+
+## Workflow
+
+1. Run `lixrl whoami --json --no-input` before authenticated work.
+2. If authentication is missing, ask the user to run `lixrl login --open` locally. For CI, point them to `LIXRL_API_KEY`.
+3. Inspect state with `lixrl urls list --json --no-input` before modifying it.
+4. Use `--json --no-input` for every automated command.
+5. Show the exact target and ask the user before adding `--yes` to delete, revoke, remove, unmap, or overwrite.
+6. Report the returned short code or resource ID. Never expose API-key values after key creation.
+
+Run `lixrl --help` for the complete command surface. Prefer `urls disable` over deletion when the desired outcome is reversible.

--- a/packages/lixrl-cli/skills/lixrl-links/agents/openai.yaml
+++ b/packages/lixrl-cli/skills/lixrl-links/agents/openai.yaml
@@ -1,0 +1,5 @@
+interface:
+  display_name: "Lixrl Links"
+  short_description: "Manage production short links from the CLI"
+  brand_color: "#9b7bf7"
+  default_prompt: "Use $lixrl-links to create and manage my Lixrl short links."

--- a/packages/lixrl-cli/skills/lixrl-qr/SKILL.md
+++ b/packages/lixrl-cli/skills/lixrl-qr/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: lixrl-qr
+description: Generate Lixrl QR images through the installed lixrl CLI. Use when a user needs a styled SVG, PNG, or JPEG QR code, or a paid tracked QR code backed by Lixrl analytics.
+---
+
+# Lixrl Qr
+
+Use the installed `lixrl` executable. Basic local QR generation does not require login. Paid styles, logos, and scan tracking use the active Lixrl profile.
+
+## Workflow
+
+1. Confirm the destination is an `http://` or `https://` URL.
+2. Default to SVG for print and scalable assets; use PNG for general sharing and JPEG only when specifically requested.
+3. Run `lixrl qr <url> --format <format> --output <path> --json --no-input`.
+4. Add `--track` only when the user requests scan analytics. Add `--style` or `--logo` only when requested.
+5. Never overwrite an existing file without explicit approval; the CLI requires both `--force` and `--yes`.
+6. Return the output path and, for tracked QR codes, the encoded Lixrl short URL.
+
+Available styles are `classic`, `rounded`, `dots`, `classy`, `aurora`, `inverse`, `sunset`, and `forest`. The active plan determines access beyond the basic styles.

--- a/packages/lixrl-cli/skills/lixrl-qr/agents/openai.yaml
+++ b/packages/lixrl-cli/skills/lixrl-qr/agents/openai.yaml
@@ -1,0 +1,5 @@
+interface:
+  display_name: "Lixrl QR"
+  short_description: "Generate styled and tracked QR codes"
+  brand_color: "#9b7bf7"
+  default_prompt: "Use $lixrl-qr to generate a QR code for this link."

--- a/packages/lixrl-cli/src/qr.js
+++ b/packages/lixrl-cli/src/qr.js
@@ -1,0 +1,93 @@
+import { readFile, writeFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+import { emit, EXIT_CODES } from './contract.js';
+
+const PRESETS = [
+  ['classic', 'square', 'square', 'square', { color: '#0b0d12' }, '#ffffff'],
+  ['rounded', 'rounded', 'extra-rounded', 'dot', { color: '#5b3df5' }, '#ffffff'],
+  ['dots', 'dots', 'dot', 'dot', { color: '#7c5cff' }, '#ffffff'],
+  ['classy', 'classy', 'square', 'square', { color: '#111827' }, '#ffffff'],
+  ['aurora', 'extra-rounded', 'extra-rounded', 'dot', { gradient: gradient('#9b7bf7', '#5fb6ff') }, '#ffffff'],
+  ['inverse', 'rounded', 'extra-rounded', 'dot', { color: '#ffffff' }, '#0b0d12'],
+  ['sunset', 'extra-rounded', 'extra-rounded', 'dot', { gradient: gradient('#ff8a5c', '#ff3d77') }, '#ffffff'],
+  ['forest', 'classy-rounded', 'extra-rounded', 'square', { gradient: gradient('#34d399', '#0ea5e9') }, '#ffffff'],
+];
+
+function gradient(...colors) {
+  return { type: 'linear', rotation: Math.PI / 4, colorStops: colors.map((color, index) => ({ offset: index, color })) };
+}
+
+function invalid(message) {
+  throw Object.assign(new Error(message), { code: 'invalid_usage', exitCode: EXIT_CODES.USAGE });
+}
+
+function normalizeUrl(value) {
+  try {
+    const url = new URL(value);
+    if (!['http:', 'https:'].includes(url.protocol)) throw new Error();
+    return url.toString();
+  } catch {
+    invalid('QR data must be a complete http:// or https:// URL.');
+  }
+}
+
+async function logoData(value) {
+  if (!value || /^https?:\/\//i.test(value) || value.startsWith('data:')) return value;
+  const extension = path.extname(value).slice(1).toLowerCase();
+  const mime = extension === 'svg' ? 'image/svg+xml' : extension === 'jpg' || extension === 'jpeg' ? 'image/jpeg' : 'image/png';
+  return `data:${mime};base64,${(await readFile(value)).toString('base64')}`;
+}
+
+export function qrRequiresLogin(options = {}) {
+  const style = options.style || 'rounded';
+  return !!options.track || !!options.logo || PRESETS.findIndex(([id]) => id === style) > 2;
+}
+
+export async function runQr(client, destination, options) {
+  const presetIndex = PRESETS.findIndex(([id]) => id === (options.style || 'rounded'));
+  if (presetIndex < 0) invalid(`Unknown QR style. Choose: ${PRESETS.map(([id]) => id).join(', ')}.`);
+  let data = normalizeUrl(destination);
+  if (qrRequiresLogin(options)) {
+    if (!client) throw Object.assign(new Error('This QR option requires login. Run lixrl login.'), { code: 'login_required', exitCode: 4 });
+    const account = await client.me();
+    const presetLimit = account.limits?.qrPresets ?? 3;
+    if (presetLimit !== -1 && presetIndex >= presetLimit) invalid('This QR style is not included in the active plan.');
+    if (options.logo && !account.limits?.qrLogo) invalid('Center logos are not included in the active plan.');
+    if (options.track) {
+      const tracked = await client.request('/api/qr/track', {
+        method: 'POST', body: { url: data, title: options.title || 'Tracked QR code' },
+      });
+      data = tracked.short_url;
+    }
+  }
+
+  const format = (options.format || 'svg').toLowerCase().replace('jpg', 'jpeg');
+  if (!['svg', 'png', 'jpeg'].includes(format)) invalid('QR format must be svg, png, jpg, or jpeg.');
+  const size = Number(options.size || 1024);
+  if (!Number.isSafeInteger(size) || size < 128 || size > 4096) invalid('QR size must be an integer from 128 to 4096 pixels.');
+  const output = options.output || `lixrl-qr.${format === 'jpeg' ? 'jpg' : format}`;
+  if (existsSync(output) && !(options.force && options.yes)) invalid(`Refusing to overwrite ${output}. Pass --force --yes to replace it.`);
+
+  const [{ default: QRCodeStyling }, { JSDOM }, nodeCanvas] = await Promise.all([
+    import('qr-code-styling'), import('jsdom'), import('@napi-rs/canvas'),
+  ]);
+  const [, dotsType, squareType, dotType, paint, background] = PRESETS[presetIndex];
+  const corner = paint.gradient ? paint.gradient.colorStops[0].color : paint.color;
+  const qr = new QRCodeStyling({
+    width: size, height: size, type: format === 'svg' ? 'svg' : 'canvas', data, margin: 8,
+    jsdom: JSDOM, nodeCanvas, image: await logoData(options.logo),
+    qrOptions: { errorCorrectionLevel: 'H' },
+    dotsOptions: { type: dotsType, ...paint },
+    cornersSquareOptions: { type: squareType, color: corner },
+    cornersDotOptions: { type: dotType, color: corner },
+    backgroundOptions: { color: background },
+    imageOptions: { margin: 6, imageSize: 0.4, hideBackgroundDots: true, saveAsBlob: true },
+  });
+  const rendered = await qr.getRawData(format);
+  if (!rendered) throw new Error('QR renderer returned no data.');
+  await writeFile(output, Buffer.from(rendered));
+  emit({ output, format, style: PRESETS[presetIndex][0], size, data, tracked: !!options.track }, options);
+}
+
+export const QR_STYLES = PRESETS.map(([id]) => id);

--- a/packages/lixrl-cli/src/skills.js
+++ b/packages/lixrl-cli/src/skills.js
@@ -1,0 +1,36 @@
+import { cp, mkdir, readdir, readFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { emit, EXIT_CODES } from './contract.js';
+
+const bundled = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../skills');
+
+export async function runSkills(action, args, options) {
+  const names = (await readdir(bundled, { withFileTypes: true })).filter((entry) => entry.isDirectory()).map((entry) => entry.name).sort();
+  if (action === 'list') return emit({ skills: names }, options);
+  const name = args[0];
+  if (!name || !names.includes(name)) {
+    throw Object.assign(new Error(`Choose a bundled skill: ${names.join(', ')}.`), { code: 'invalid_skill', exitCode: EXIT_CODES.USAGE });
+  }
+  if (action === 'inspect') {
+    const content = await readFile(path.join(bundled, name, 'SKILL.md'), 'utf8');
+    if (options.json) return emit({ name, content }, options);
+    process.stdout.write(content);
+    return;
+  }
+  if (action === 'install') {
+    const root = options.target || path.join(process.env.CODEX_HOME || path.join(os.homedir(), '.codex'), 'skills');
+    const target = path.join(root, name);
+    if (existsSync(target) && !(options.force && options.yes)) {
+      throw Object.assign(new Error(`Refusing to replace ${target}. Pass --force --yes to update it.`), {
+        code: 'confirmation_required', exitCode: 5,
+      });
+    }
+    await mkdir(root, { recursive: true });
+    await cp(path.join(bundled, name), target, { recursive: true, force: true });
+    return emit({ installed: name, target }, options);
+  }
+  throw Object.assign(new Error('Usage: lixrl skills <list|inspect|install> [name]'), { exitCode: EXIT_CODES.USAGE });
+}

--- a/packages/lixrl-cli/tests/qr-skills.test.mjs
+++ b/packages/lixrl-cli/tests/qr-skills.test.mjs
@@ -1,0 +1,23 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, readFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { qrRequiresLogin, QR_STYLES } from '../src/qr.js';
+import { runSkills } from '../src/skills.js';
+
+test('basic QR styles stay local while paid features require login', () => {
+  assert.equal(qrRequiresLogin({ style: 'classic' }), false);
+  assert.equal(qrRequiresLogin({ style: 'rounded' }), false);
+  assert.equal(qrRequiresLogin({ style: 'aurora' }), true);
+  assert.equal(qrRequiresLogin({ track: true }), true);
+  assert.deepEqual(QR_STYLES, ['classic', 'rounded', 'dots', 'classy', 'aurora', 'inverse', 'sunset', 'forest']);
+});
+
+test('bundled skills install from the npm package', async () => {
+  const target = await mkdtemp(path.join(os.tmpdir(), 'lixrl-skills-'));
+  await runSkills('install', ['lixrl-links'], { target, quiet: true });
+  const content = await readFile(path.join(target, 'lixrl-links', 'SKILL.md'), 'utf8');
+  assert.match(content, /name: lixrl-links/);
+  assert.match(content, /lixrl urls list/);
+});


### PR DESCRIPTION
## What this does
Completes `@elixpo/lixrl-cli` v1.0.1 with local SVG, PNG, and JPEG QR generation, package-bundled agent skills, and a gated npm release workflow.

## Why
The release needs QR workflows and installable automation guidance without exposing credentials or copying skills outside the npm package automatically.

## Changes
- eight QR presets with plan-aware styles, logos, and tracking
- native 128–4096px SVG, PNG, JPEG exports
- `lixrl-links` and `lixrl-qr` skills with list/inspect/install commands
- overwrite protection and explicit confirmation
- package gate, smoke test, provenance attestation, and npm publish workflow
- threat model and release checklist

## Verification
- package tests pass
- SVG, PNG, and JPEG fixtures identified correctly
- both skills pass `quick_validate.py`
- npm dry run includes only 19 intended files

---
Fixes #49