### PR TITLE
[ELIXPO] Add Developer CLI documentation

### DIFF
--- a/app/LandingPageClient.tsx
+++ b/app/LandingPageClient.tsx
@@ -247,6 +247,14 @@ export default function LandingPage() {
               with click analytics, custom slugs, and a REST API, all from one
               dashboard.
             </p>
+            <Link
+              href="/docs/cli"
+              className="btn-glass inline-flex items-center gap-2 no-underline"
+              style={{ borderRadius: 9, padding: '10px 16px', fontSize: 14 }}
+            >
+              Developer CLI
+              <ArrowIcon />
+            </Link>
           </div>
 
           {/* Static brand artwork — blends into the white hero surface. */}

--- a/app/docs/cli/page.tsx
+++ b/app/docs/cli/page.tsx
@@ -1,0 +1,227 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import type { ReactNode } from 'react';
+
+export const runtime = 'edge';
+
+export const metadata: Metadata = {
+  title: '@elixpo/lixrl-cli — Developer CLI',
+  description:
+    'Install the official Lixrl CLI to shorten URLs, manage links and analytics, generate QR codes, and automate Lixrl safely from agents and CI.',
+  alternates: { canonical: '/docs/cli' },
+};
+
+const H2 = 'mt-12 mb-3 text-[1.45rem] font-extrabold tracking-tight text-[#111]';
+const H3 = 'mt-7 mb-2 text-[1.05rem] font-bold text-[#222]';
+const P = 'mb-4 max-w-[760px] text-[0.96rem] leading-7 text-[#555]';
+const CODE =
+  'mb-5 overflow-x-auto rounded-xl border border-[#262a3a] bg-[#16192a] p-4 font-mono text-[0.84rem] leading-6 text-[#f1f1f5]';
+
+function Command({ children }: { children: string }) {
+  return (
+    <pre className={CODE}>
+      <code>{children}</code>
+    </pre>
+  );
+}
+
+function Note({ children }: { children: ReactNode }) {
+  return (
+    <div className="my-5 rounded-xl border border-[#f2c6c4] bg-[#fff7f6] px-4 py-3 text-sm leading-6 text-[#633]">
+      {children}
+    </div>
+  );
+}
+
+export default function CliDocsPage() {
+  return (
+    <article className="text-[#111]">
+      <div className="rounded-2xl border border-[#e6e2dc] bg-gradient-to-br from-white to-[#fff8f7] p-6 md:p-8">
+        <div className="mb-4 inline-flex rounded-full border border-[#f1c8c6] bg-white px-3 py-1 font-mono text-xs font-semibold text-[#c62828]">
+          @elixpo/lixrl-cli · v1.0.1
+        </div>
+        <h1 className="mb-4 max-w-[760px] text-[2.2rem] font-black leading-tight tracking-[-0.035em] text-[#111] md:text-[2.8rem]">
+          Short links and QR codes from your terminal
+        </h1>
+        <p className="max-w-[740px] text-base leading-7 text-[#555] md:text-[1.05rem]">
+          The official Lixrl CLI creates and manages production links, exports
+          analytics, generates styled QR images, and gives agents a stable JSON
+          interface without exposing dashboard sessions.
+        </p>
+        <div className="mt-6 flex flex-wrap gap-3">
+          <a
+            href="https://www.npmjs.com/package/@elixpo/lixrl-cli"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="rounded-lg bg-[#e53935] px-4 py-2.5 text-sm font-bold text-white no-underline"
+          >
+            View npm package
+          </a>
+          <Link
+            href="/profile/keys"
+            className="rounded-lg border border-[#d8d8d8] bg-white px-4 py-2.5 text-sm font-bold text-[#222] no-underline"
+          >
+            Create an API key
+          </Link>
+        </div>
+      </div>
+
+      <h2 id="install" className={H2}>Install</h2>
+      <p className={P}>
+        Node.js 20 or newer is required. The package installs both{' '}
+        <code className="font-mono text-[#222]">lixrl</code> and the compatible{' '}
+        <code className="font-mono text-[#222]">shortner</code> alias.
+      </p>
+      <Command>{`npm install --global @elixpo/lixrl-cli
+lixrl --version
+lixrl --help`}</Command>
+
+      <h2 id="sign-in" className={H2}>Sign in and authenticate</h2>
+      <p className={P}>
+        Browser sessions and CLI credentials have separate jobs. First sign in
+        with Elixpo Accounts to create a scoped Lixrl API key. The CLI then
+        validates that key and stores it in your operating-system keychain.
+      </p>
+
+      <h3 id="interactive-login" className={H3}>Interactive login</h3>
+      <ol className="mb-5 list-decimal space-y-2 pl-6 text-[0.96rem] leading-7 text-[#555]">
+        <li>
+          <Link href="/api/auth/login?return_to=/profile/keys" className="font-semibold text-[#c62828]">
+            Sign in to Lixrl
+          </Link>{' '}
+          and open <strong>Profile → API Keys</strong>.
+        </li>
+        <li>
+          Create a <code className="font-mono">read,write</code> key for link
+          creation, or a <code className="font-mono">read</code> key for
+          inspection, analytics, and exports only.
+        </li>
+        <li>Copy the key when it is shown. Lixrl stores only its hash and cannot display it again.</li>
+        <li>Run the login command and paste the key into the masked prompt.</li>
+      </ol>
+      <Command>{`lixrl login --open
+lixrl whoami`}</Command>
+      <Note>
+        Never place an <code className="font-mono">elu_…</code> key in a URL,
+        source file, generated article, issue, or chat message. Interactive
+        login writes the credential to the OS keychain, not the CLI config file.
+      </Note>
+
+      <h3 id="profiles" className={H3}>Multiple accounts</h3>
+      <Command>{`lixrl login --profile work --open
+lixrl profiles
+lixrl use work
+lixrl whoami --profile work`}</Command>
+      <p className={P}>
+        Profile names are non-secret aliases. Each profile&apos;s API key remains
+        in the keychain. Logging out removes only the selected local credential;
+        revoke the key separately when it must stop working everywhere.
+      </p>
+      <Command>{`lixrl keys revoke 42 --yes
+lixrl logout --profile work --yes`}</Command>
+
+      <h3 id="ci-authentication" className={H3}>CI and non-interactive agents</h3>
+      <p className={P}>
+        Store the key in the CI provider&apos;s encrypted secret store and expose it
+        only to the command process as <code className="font-mono">LIXRL_API_KEY</code>.
+        Automation should always add <code className="font-mono">--json --no-input</code>.
+      </p>
+      <Command>{`lixrl whoami --json --no-input
+lixrl urls create "https://example.com/article" \
+  --title "Article" --tag automation --json --no-input`}</Command>
+
+      <h2 id="links" className={H2}>Manage short links</h2>
+      <Command>{`# Create
+lixrl urls create "https://example.com/launch" \
+  --title "Launch" --campaign launch --tag release
+
+# Search and inspect
+lixrl urls list --search launch --limit 25
+lixrl urls get abc123
+
+# Update or pause without deleting
+lixrl urls update abc123 --destination "https://example.com/new"
+lixrl urls disable abc123
+lixrl urls enable abc123
+
+# Destructive operations require confirmation
+lixrl urls delete abc123 --yes`}</Command>
+      <p className={P}>
+        Paid plans can add custom slugs and expiry dates with{' '}
+        <code className="font-mono">--slug</code> and{' '}
+        <code className="font-mono">--expires</code>. Bulk creation accepts a
+        JSON array through <code className="font-mono">--file</code>.
+      </p>
+
+      <h2 id="analytics" className={H2}>Analytics and exports</h2>
+      <Command>{`lixrl urls analytics abc123 --days 30 --json
+lixrl urls export --output links.csv
+lixrl urls export-clicks abc123 --output clicks.csv`}</Command>
+      <p className={P}>
+        Exports refuse to replace an existing file. An intentional replacement
+        requires both <code className="font-mono">--force</code> and{' '}
+        <code className="font-mono">--yes</code>.
+      </p>
+
+      <h2 id="qr-codes" className={H2}>Generate QR codes</h2>
+      <p className={P}>
+        Basic QR generation runs locally. SVG is the best default for print;
+        PNG and JPEG are available for image workflows. Paid styles, center
+        logos, and tracked QR links verify the active account plan.
+      </p>
+      <Command>{`lixrl qr "https://example.com" --format svg --output code.svg
+lixrl qr "https://example.com" --format png --style rounded --size 1024 --output code.png
+lixrl qr "https://example.com" --track --style aurora --title "Print campaign" --output tracked.svg`}</Command>
+
+      <h2 id="domains-and-keys" className={H2}>API keys and branded subdomains</h2>
+      <Command>{`lixrl keys list
+lixrl keys create --name deploy --scopes read,write
+
+lixrl domains list
+lixrl domains claim team
+lixrl domains verify 12
+lixrl domains map 12 abc123 --slug launch`}</Command>
+      <p className={P}>
+        Key creation prints the secret once. Capture it directly into the
+        intended secret store and do not include command output in logs.
+        Subdomain commands follow your current plan entitlement.
+      </p>
+
+      <h2 id="agent-skills" className={H2}>Agent skills</h2>
+      <p className={P}>
+        The npm artifact includes focused skills for link management and QR
+        generation. Nothing is copied during package installation; install only
+        the skill the agent needs.
+      </p>
+      <Command>{`lixrl skills list
+lixrl skills inspect lixrl-links
+lixrl skills install lixrl-links
+lixrl skills install lixrl-qr`}</Command>
+      <p className={P}>
+        The link skill contains a separate writing workflow: agents shorten
+        only public canonical destinations selected by the author, preserve the
+        original destination, and request approval before replacing a link in a
+        post. LixBlogs OAuth tokens are never reused as Lixrl credentials.
+      </p>
+
+      <h2 id="automation-contract" className={H2}>Automation contract</h2>
+      <ul className="mb-6 list-disc space-y-2 pl-6 text-[0.96rem] leading-7 text-[#555]">
+        <li><code className="font-mono">--json</code> returns stable machine-readable output.</li>
+        <li><code className="font-mono">--no-input</code> prevents hidden prompts in agents and CI.</li>
+        <li>Deletion, revocation, unmapping, and overwrite operations require <code className="font-mono">--yes</code>.</li>
+        <li>Exit code 2 means invalid usage, 4 means authentication is required, and 5 means confirmation is missing.</li>
+        <li>API errors may include a request ID for support; credentials are redacted.</li>
+      </ul>
+
+      <h2 id="configuration" className={H2}>Configuration</h2>
+      <p className={P}>
+        Production defaults to <code className="font-mono">https://lixrl.com</code>.
+        Use <code className="font-mono">--api-url</code> or{' '}
+        <code className="font-mono">LIXRL_API_URL</code> only for an intentional
+        Lixrl environment. Non-local HTTP origins are rejected.
+      </p>
+      <Command>{`lixrl --help
+lixrl whoami --profile default --json --no-input`}</Command>
+    </article>
+  );
+}

--- a/app/docs/layout.tsx
+++ b/app/docs/layout.tsx
@@ -13,6 +13,7 @@ const REPO_URL = 'https://github.com/elixpo/elixpourl';
 const DOCS_NAV = [
   { label: 'Overview', href: '/docs' },
   { label: 'Quickstart', href: '/docs/quickstart' },
+  { label: 'Developer CLI', href: '/docs/cli' },
   { label: 'Shortening API', href: '/docs/api' },
   { label: 'API Keys', href: '/docs/keys' },
   { label: 'Click Analytics', href: '/docs/analytics' },

--- a/app/docs/llm_text.ts
+++ b/app/docs/llm_text.ts
@@ -49,6 +49,53 @@ Users sign in via Elixpo Accounts SSO (no separate password). For machine-to-mac
 
 ---
 
+# Developer CLI — @elixpo/lixrl-cli
+
+Install the official CLI with Node.js 20 or newer:
+
+\`\`\`bash
+npm install --global @elixpo/lixrl-cli
+lixrl --help
+\`\`\`
+
+## Interactive authentication
+
+1. Sign in at \`https://lixrl.com/api/auth/login?return_to=/profile/keys\`.
+2. Create a scoped API key under **Profile → API Keys**. Use \`read,write\` to create or modify links and \`read\` for inspection and analytics only.
+3. Run \`lixrl login --open\` and paste the key into the masked prompt.
+4. Verify the active identity with \`lixrl whoami\`.
+
+Interactive credentials are stored in the operating-system keychain. The CLI config stores profile aliases only. Never put an \`elu_…\` key in a URL, source file, issue, chat message, or generated article.
+
+## CI and agents
+
+Provide \`LIXRL_API_KEY\` through the CI platform secret store and always use \`--json --no-input\`:
+
+\`\`\`bash
+lixrl whoami --json --no-input
+lixrl urls create "https://example.com/article" --title "Article" --tag automation --json --no-input
+\`\`\`
+
+## Common commands
+
+\`\`\`bash
+lixrl urls list --search launch --json
+lixrl urls analytics abc123 --days 30 --json
+lixrl urls export --output links.csv
+lixrl qr "https://example.com" --format svg --output code.svg
+lixrl qr "https://example.com" --track --style aurora --output tracked.svg
+lixrl domains list
+lixrl skills install lixrl-links
+\`\`\`
+
+Deletion, key revocation, subdomain unmapping, and file replacement require explicit confirmation. Agent workflows must not add \`--yes\` without user approval.
+
+For published writing, shorten only public canonical destinations selected by the author. Preserve the original destination, show the proposed replacement, and obtain approval before changing the post. LixBlogs OAuth tokens and Lixrl API keys are separate credentials and must never be substituted.
+
+Full guide: \`https://lixrl.com/docs/cli\`.
+
+---
+
 # Authentication
 
 Endpoints require a scoped API key in the standard Bearer header:

--- a/app/docs/page.tsx
+++ b/app/docs/page.tsx
@@ -40,7 +40,7 @@ export default function OverviewPage() {
 
       <h2 id="get-started" className={H2}>Get started</h2>
       <p className={P}>
-        Three ways into ElixpoURL, depending on how you like to work.
+        Choose the dashboard, Developer CLI, or API depending on how you work.
       </p>
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 mb-6">
         <Link href="/docs/quickstart" className={CARD} style={CARD_STYLE}>
@@ -53,6 +53,12 @@ export default function OverviewPage() {
           <div className="font-semibold text-white mb-1">Shortening API</div>
           <div className="text-sm text-white/55">
             Endpoints to create, list, update, and delete short links.
+          </div>
+        </Link>
+        <Link href="/docs/cli" className={CARD} style={CARD_STYLE}>
+          <div className="font-semibold text-white mb-1">Developer CLI</div>
+          <div className="text-sm text-white/55">
+            Shorten links, export analytics, and generate QR codes from a terminal or agent workflow.
           </div>
         </Link>
         <Link href="/docs/analytics" className={CARD} style={CARD_STYLE}>

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -57,6 +57,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
 
   const docsSections: MetadataRoute.Sitemap = [
     'quickstart',
+    'cli',
     'api',
     'keys',
     'analytics',

--- a/packages/lixrl-cli/README.md
+++ b/packages/lixrl-cli/README.md
@@ -10,6 +10,15 @@ lixrl whoami
 
 Create a read/write API key at [lixrl.com/profile/keys](https://lixrl.com/profile/keys). Interactive login stores the key in the operating-system keychain. CI can provide `LIXRL_API_KEY` without writing it to disk.
 
+## Sign in securely
+
+1. Sign in to [Lixrl](https://lixrl.com/api/auth/login?return_to=/profile/keys) with your Elixpo account.
+2. Create a key under **Profile → API Keys**. Use `read,write` for link creation or `read` for inspection and analytics only.
+3. Run `lixrl login --open`, then paste the key into the masked prompt.
+4. Verify the active identity with `lixrl whoami`.
+
+The CLI stores interactive credentials in the OS keychain. For CI, set `LIXRL_API_KEY` through the CI secret store and use `--json --no-input`; never place the key in source files or command arguments.
+
 Use `lixrl --help` for the complete command list. `shortner` is provided as a compatibility alias.
 
 ## Core workflows

--- a/packages/lixrl-cli/skills/lixrl-links/SKILL.md
+++ b/packages/lixrl-cli/skills/lixrl-links/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: lixrl-links
-description: Manage Lixrl production short links through the installed lixrl CLI. Use when creating, listing, editing, disabling, deleting, exporting, or inspecting analytics for Lixrl links, or when managing Lixrl API keys and paid subdomains.
+description: Manage Lixrl production short links through the installed lixrl CLI. Use when creating, listing, editing, disabling, deleting, exporting, or inspecting analytics for Lixrl links, including links selected for articles or agent-assisted publishing.
 ---
 
 # Lixrl Links
@@ -10,10 +10,13 @@ Use the installed `lixrl` executable. Do not read credential files or ask the us
 ## Workflow
 
 1. Run `lixrl whoami --json --no-input` before authenticated work.
-2. If authentication is missing, ask the user to run `lixrl login --open` locally. For CI, point them to `LIXRL_API_KEY`.
-3. Inspect state with `lixrl urls list --json --no-input` before modifying it.
-4. Use `--json --no-input` for every automated command.
-5. Show the exact target and ask the user before adding `--yes` to delete, revoke, remove, unmap, or overwrite.
-6. Report the returned short code or resource ID. Never expose API-key values after key creation.
+2. If authentication is missing, ask the user to sign in at `https://lixrl.com`, create an appropriately scoped key at `https://lixrl.com/profile/keys`, and run `lixrl login --open` locally. The CLI prompts for the key without echoing it and stores it in the OS keychain.
+3. For CI only, use the platform secret store to provide `LIXRL_API_KEY`; never write it to a file, command argument, generated post, or log.
+4. Inspect state with `lixrl urls list --json --no-input` before modifying it.
+5. Use `--json --no-input` for every automated command.
+6. Show the exact target and ask the user before adding `--yes` to delete, revoke, remove, unmap, or overwrite.
+7. Report the returned short code or resource ID. Never expose API-key values after key creation.
 
 Run `lixrl --help` for the complete command surface. Prefer `urls disable` over deletion when the desired outcome is reversible.
+
+For articles, release notes, or agent-authored posts, read [references/blog-writing.md](references/blog-writing.md) before creating or replacing links.

--- a/packages/lixrl-cli/skills/lixrl-links/references/blog-writing.md
+++ b/packages/lixrl-cli/skills/lixrl-links/references/blog-writing.md
@@ -1,0 +1,23 @@
+# Short links in published writing
+
+Use Lixrl only for public destinations the author deliberately selects. Do not shorten draft URLs, preview links, private documents, citations, source references, or every link in a post automatically.
+
+## Procedure
+
+1. Identify the canonical destination and confirm it is already public.
+2. Show the author the destination, proposed title, campaign, tags, and where the short link will appear. Obtain approval before changing the post.
+3. Create the link with attributable metadata:
+
+```bash
+lixrl urls create "https://example.com/canonical-page" \
+  --title "Post title — destination" \
+  --campaign "blog-post-slug" \
+  --tag blog \
+  --tag "post-slug" \
+  --json --no-input
+```
+
+4. Replace only the approved occurrence and preserve the original destination in the authoring record.
+5. Before publication, verify the returned short URL resolves to the intended canonical destination.
+
+If Lixrl authentication is missing, stop without changing the draft. Ask the user to complete `lixrl login --open`, then verify with `lixrl whoami --json --no-input`. LixBlogs OAuth credentials and Lixrl API keys are separate and must never be substituted for each other.


### PR DESCRIPTION
## Summary

- add a dedicated Developer CLI guide covering installation, scoped authentication, profiles, CI, URL management, analytics, QR generation, domains, and automation contracts
- expose the guide in the landing hero, docs navigation, overview, sitemap, and Copy for LLM reference
- extend the packaged lixrl-links skill with a safe agent-writing workflow and separate LixBlogs/Lixrl credential guidance

## Verification

- packaged skill validation passed
- CLI test suite passed
- edge-runtime audit passed with 11 gapless migrations
- diff check passed

Related: elixpo/blogs.elixpo#253

Fixes #57