### PR TITLE
[ELIXPO] Improve CLI login and terminal errors

### DIFF
--- a/app/api/cli/auth/requests/[id]/token/route.ts
+++ b/app/api/cli/auth/requests/[id]/token/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { auditLog } from '@/lib/auth';
-import { getDB } from '@/lib/db';
+import { getDB, getOrigin } from '@/lib/db';
 import { rateLimit } from '@/lib/ratelimit';
 import { TIER_LIMITS, type Tier } from '@/lib/types';
 import { generateApiKey, hashApiKey } from '@/lib/utils';
@@ -53,7 +53,14 @@ export async function POST(
     'SELECT COUNT(*) as count FROM api_keys WHERE user_id = ? AND is_active = 1',
   ).bind(row.user_id).first<{ count: number }>();
   if ((keyCount?.count || 0) >= limits.maxApiKeys) {
-    return NextResponse.json({ error: `API key limit reached (${limits.maxApiKeys} for ${row.tier} tier)` }, { status: 403 });
+    return NextResponse.json({
+      error: `API key limit reached (${limits.maxApiKeys} for ${row.tier} tier)`,
+      code: 'api_key_limit_reached',
+      limit: limits.maxApiKeys,
+      tier: row.tier,
+      manage_url: `${getOrigin(request.url)}/profile/keys`,
+      retry_command: 'lixrl login --open',
+    }, { status: 403 });
   }
 
   const rawKey = generateApiKey();

--- a/app/api/cli/auth/requests/route.ts
+++ b/app/api/cli/auth/requests/route.ts
@@ -38,6 +38,10 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({
       error: `API key limit reached (${limits.maxApiKeys} for ${user.tier} tier)`,
       code: 'api_key_limit_reached',
+      limit: limits.maxApiKeys,
+      tier: user.tier,
+      manage_url: `${getOrigin(request.url)}/profile/keys`,
+      retry_command: 'lixrl login --open',
     }, { status: 403 });
   }
 

--- a/app/api/keys/route.ts
+++ b/app/api/keys/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { resolveUser, auditLog } from '@/lib/auth';
-import { getDB } from '@/lib/db';
+import { getDB, getOrigin } from '@/lib/db';
 import { generateApiKey, hashApiKey } from '@/lib/utils';
 import { TIER_LIMITS } from '@/lib/types';
 import { validateLength, isValidScopes, badRequest } from '@/lib/validate';
@@ -35,7 +35,14 @@ export async function POST(request: NextRequest) {
     .bind(user.id).first<{ count: number }>();
 
   if ((keyCount?.count || 0) >= limits.maxApiKeys) {
-    return NextResponse.json({ error: `API key limit reached (${limits.maxApiKeys} for ${user.tier} tier)` }, { status: 403 });
+    return NextResponse.json({
+      error: `API key limit reached (${limits.maxApiKeys} for ${user.tier} tier)`,
+      code: 'api_key_limit_reached',
+      limit: limits.maxApiKeys,
+      tier: user.tier,
+      manage_url: `${getOrigin(request.url)}/profile/keys`,
+      retry_command: 'lixrl keys create --name <name>',
+    }, { status: 403 });
   }
 
   const rawKey = generateApiKey();

--- a/app/docs/cli/page.tsx
+++ b/app/docs/cli/page.tsx
@@ -125,8 +125,8 @@ lixrl --help`}</Command>
 
       <h3 id="device-login" className={H3}>Recommended: Accounts device login</h3>
       <ol className="mb-5 list-decimal space-y-2 pl-6 text-[0.96rem] leading-7 text-[#555]">
-        <li>Run the command. The CLI displays an official Accounts URL and one-time code.</li>
-        <li>Approve the Lixrl CLI in your browser. Use <code className="font-mono">--open</code> to open that page automatically.</li>
+        <li>Run the command. The CLI displays a prefilled official Accounts URL and one-time code.</li>
+        <li>Press Enter to open the URL, or use <code className="font-mono">--open</code> to launch it immediately.</li>
         <li>The CLI opens a Lixrl approval page where you choose the key name, read or read/write access, and an optional expiry.</li>
         <li>Lixrl enforces your plan&apos;s key limit, delivers the key directly to the waiting CLI, and stores only its hash.</li>
       </ol>
@@ -136,6 +136,8 @@ lixrl whoami`}</Command>
         Read-only keys can list links, analytics, and exports without changing
         data. Read/write keys can also create, update, disable, and delete
         links. The approval screen shows the active-key allowance for your plan.
+        If that allowance is full, the CLI offers to open key management and
+        retry after you revoke an unused key.
       </p>
       <Note>
         The one-time code authorizes only the displayed Lixrl request. Temporary

--- a/packages/lixrl-cli/README.md
+++ b/packages/lixrl-cli/README.md
@@ -19,7 +19,7 @@ lixrl login --open
 lixrl whoami
 ```
 
-The CLI first displays a one-time code and the official Accounts URL. After identity approval, it opens a Lixrl page where you choose the key name, read or read/write access, and an optional expiry date. Lixrl enforces your plan's API-key limit, then delivers the new key directly to the waiting CLI. Passwords, browser cookies, and Accounts refresh tokens are never stored by the CLI.
+The CLI displays a prefilled Accounts URL and one-time code. Press Enter to open it or use `--open` to launch it immediately. After identity approval, Lixrl asks you to choose the key name, read or read/write access, and an optional expiry date. If your plan has no free key slot, the CLI offers to open key management so you can revoke an unused key and retry without starting the Accounts login again. Passwords, browser cookies, and Accounts refresh tokens are never stored by the CLI.
 
 ### Paste an existing key
 

--- a/packages/lixrl-cli/bin/shortner.mjs
+++ b/packages/lixrl-cli/bin/shortner.mjs
@@ -6,7 +6,16 @@ import { resolveConfig, ProfileRegistry, validateProfile } from '../src/config.j
 import { CredentialStore, validateKey } from '../src/credentials.js';
 import { LixrlClient } from '../src/client.js';
 import { emit, fail, EXIT_CODES } from '../src/contract.js';
-import { openBrowser, promptSecret } from '../src/ui.js';
+import {
+  approvalChallenge,
+  colorEnabled,
+  listenForEnter,
+  loginChallenge,
+  openBrowser,
+  promptConfirm,
+  promptSecret,
+  successLine,
+} from '../src/ui.js';
 import { runDomains, runKeys, runUrls } from '../src/commands.js';
 import { qrRequiresLogin, runQr } from '../src/qr.js';
 import { runSkills } from '../src/skills.js';
@@ -131,6 +140,8 @@ async function main(argv = process.argv.slice(2)) {
       key = validateKey(process.env.LIXRL_API_KEY || await promptSecret('Paste Lixrl API key: '));
       user = await new LixrlClient({ apiUrl: config.apiUrl, apiKey: key }).me();
     } else {
+      const progress = !options.quiet && !options.json;
+      const color = colorEnabled(process.stderr);
       const deviceConfig = await fetchLixrlCliConfig({ apiUrl: config.apiUrl });
       const auth = new AccountsDeviceAuth({
         accountsUrl: options['accounts-url'] || deviceConfig.accountsUrl,
@@ -138,22 +149,50 @@ async function main(argv = process.argv.slice(2)) {
         audience: deviceConfig.audience,
       });
       const challenge = await auth.requestDeviceCode();
-      if (!options.quiet) {
-        process.stderr.write(`Open ${challenge.verificationUri}\nEnter code: ${challenge.userCode}\n`);
+      const approvalUrl = challenge.verificationUriComplete || challenge.verificationUri;
+      if (progress) process.stderr.write(`${loginChallenge({
+        url: approvalUrl,
+        code: challenge.userCode,
+        expiresInSeconds: challenge.expiresInSeconds,
+        profile,
+        interactive: process.stdin.isTTY && !options.open,
+        color,
+      })}\n`);
+      let stopListening = () => {};
+      if (options.open) openBrowser(approvalUrl);
+      else if (progress && process.stdin.isTTY) {
+        stopListening = listenForEnter({ open: openBrowser, url: approvalUrl });
       }
-      if (options.open) openBrowser(challenge.verificationUriComplete);
-      const token = await waitForDeviceApproval(auth, challenge);
+      let token;
+      try {
+        token = await waitForDeviceApproval(auth, challenge);
+      } finally {
+        stopListening();
+      }
       let authorization;
       try {
-        authorization = await startLixrlAuthorization({
+        const startAuthorization = () => startLixrlAuthorization({
           apiUrl: config.apiUrl,
           accessToken: token.accessToken,
         });
+        try {
+          authorization = await startAuthorization();
+        } catch (error) {
+          const recoverable = ['api_key_limit_reached', 'key_limit_reached'].includes(error?.code);
+          const interactive = !options.quiet && !options.json && !options['no-input'];
+          if (!recoverable || !interactive) throw error;
+
+          const manageUrl = error.details?.manage_url || `${config.apiUrl}/profile/keys`;
+          if (!await promptConfirm('API key limit reached. Open key settings to revoke one?')) throw error;
+          openBrowser(manageUrl);
+          if (!await promptConfirm('After revoking an unused key, retry login now?')) throw error;
+          authorization = await startAuthorization();
+        }
       } finally {
         await auth.revoke(token.refreshToken);
         await auth.revoke(token.accessToken);
       }
-      if (!options.quiet) process.stderr.write(`Review key access at ${authorization.approvalUrl}\n`);
+      if (progress) process.stderr.write(`${approvalChallenge({ url: authorization.approvalUrl, color })}\n`);
       if (options.open) openBrowser(authorization.approvalUrl);
       const result = await waitForLixrlApproval(config.apiUrl, authorization);
       key = validateKey(result.key);
@@ -162,7 +201,13 @@ async function main(argv = process.argv.slice(2)) {
 
     if (!process.env.LIXRL_API_KEY) await credentials.set(profile, key);
     await registry.add(profile);
-    return emit({ profile, user: { email: user.email, display_name: user.display_name, tier: user.tier } }, options);
+    const loginResult = { profile, user: { email: user.email, display_name: user.display_name, tier: user.tier } };
+    if (options.json) return emit(loginResult, options);
+    if (!options.quiet) {
+      process.stdout.write(`${successLine(`Logged in as ${user.email} (${profile}).`, colorEnabled(process.stdout))}\n`);
+      process.stdout.write('  Credentials saved securely in the OS keychain.\n');
+    }
+    return undefined;
   }
 
   if (command === 'profiles') {

--- a/packages/lixrl-cli/src/client.js
+++ b/packages/lixrl-cli/src/client.js
@@ -51,7 +51,7 @@ export class LixrlClient {
     if (!response.ok) {
       throw new ApiError(payload?.error || `Lixrl returned HTTP ${response.status}.`, {
         status: response.status,
-        code: response.status === 401 ? 'login_required' : `http_${response.status}`,
+        code: response.status === 401 ? 'login_required' : payload?.code || `http_${response.status}`,
         requestId: response.headers.get('x-request-id'),
         details: payload,
       });

--- a/packages/lixrl-cli/src/contract.js
+++ b/packages/lixrl-cli/src/contract.js
@@ -1,3 +1,5 @@
+import { colorEnabled, failureBlock } from './ui.js';
+
 export const EXIT_CODES = Object.freeze({ OK: 0, ERROR: 1, USAGE: 2, AUTH: 4, CONFIRMATION: 5 });
 
 export function safeJson(value) {
@@ -28,7 +30,10 @@ export function fail(error, options = {}) {
     },
   };
   if (options.json) process.stderr.write(`${safeJson(payload)}\n`);
-  else if (!options.quiet) process.stderr.write(`Error: ${payload.error.message}\n`);
+  else if (!options.quiet) process.stderr.write(`${failureBlock({
+    ...payload.error,
+    details: error?.details,
+  }, colorEnabled(process.stderr))}\n`);
   process.exitCode = error?.exitCode || (error?.code === 'login_required' ? EXIT_CODES.AUTH : EXIT_CODES.ERROR);
 }
 

--- a/packages/lixrl-cli/src/device-auth.js
+++ b/packages/lixrl-cli/src/device-auth.js
@@ -201,8 +201,9 @@ export async function startLixrlAuthorization({ apiUrl, accessToken, fetchImpl =
   });
   const payload = await json(response);
   if (!response.ok || !payload.request_id || !payload.poll_secret || !payload.approval_url) {
-    const error = new DeviceAuthError(response.status === 403 ? 'key_limit_reached' : 'authorization_start_failed', response.status);
+    const error = new DeviceAuthError(payload.code || (response.status === 403 ? 'key_limit_reached' : 'authorization_start_failed'), response.status);
     error.message = payload.error || error.message;
+    error.details = payload;
     throw error;
   }
   return {
@@ -224,8 +225,9 @@ export async function pollLixrlAuthorization({ apiUrl, requestId, pollSecret, fe
   const payload = await json(response);
   if (response.status === 202 && payload.status === 'pending') return { status: 'pending' };
   if (!response.ok || typeof payload.key !== 'string') {
-    const error = new DeviceAuthError(response.status === 403 ? 'access_denied' : 'key_exchange_failed', response.status);
+    const error = new DeviceAuthError(payload.code || (response.status === 403 ? 'access_denied' : 'key_exchange_failed'), response.status);
     error.message = payload.error || error.message;
+    error.details = payload;
     throw error;
   }
   return payload;

--- a/packages/lixrl-cli/src/ui.js
+++ b/packages/lixrl-cli/src/ui.js
@@ -1,4 +1,86 @@
 import { spawn } from 'node:child_process';
+import { createInterface } from 'node:readline/promises';
+
+const ANSI = Object.freeze({
+  reset: '\u001b[0m',
+  bold: '\u001b[1m',
+  dim: '\u001b[2m',
+  violet: '\u001b[38;5;141m',
+  green: '\u001b[38;5;42m',
+  red: '\u001b[38;5;203m',
+  yellow: '\u001b[38;5;220m',
+});
+
+export function colorEnabled(stream = process.stderr, env = process.env) {
+  return Boolean(stream.isTTY) && env.NO_COLOR === undefined && env.TERM !== 'dumb';
+}
+
+function paint(value, code, enabled) {
+  return enabled ? `${code}${value}${ANSI.reset}` : value;
+}
+
+export function loginChallenge({ url, code, expiresInSeconds, profile, interactive, color = false }) {
+  const instruction = interactive
+    ? 'Press Enter to open here, or use the URL on another device.'
+    : 'Open the URL in any browser and approve this device.';
+  return [
+    '',
+    `  ${paint('◆', ANSI.violet, color)} ${paint('Lixrl', ANSI.bold, color)}`,
+    `  ${paint('Device login', ANSI.dim, color)}`,
+    '  ─────────────────────────────────────────',
+    `  URL      ${url}`,
+    `  Code     ${paint(code, ANSI.bold, color)}`,
+    `  Expires  ${Math.ceil(expiresInSeconds / 60)} min`,
+    `  Profile  ${profile} ${paint('(local credential slot)', ANSI.dim, color)}`,
+    '',
+    `  ${instruction}`,
+    '  No localhost callback or exposed port is required.',
+    '',
+  ].join('\n');
+}
+
+export function approvalChallenge({ url, color = false }) {
+  return [
+    '',
+    `  ${paint('✓', ANSI.green, color)} Identity approved`,
+    `  ${paint('→', ANSI.violet, color)} Review key access  ${url}`,
+    '',
+  ].join('\n');
+}
+
+export function successLine(message, color = false) {
+  return `  ${paint('✓', ANSI.green, color)} ${message}`;
+}
+
+export function failureBlock(error, color = false) {
+  const lines = [`  ${paint('✘', ANSI.red, color)} ${paint(error.message, ANSI.bold, color)}`];
+  if (error.code === 'api_key_limit_reached' || error.code === 'key_limit_reached') {
+    const limit = Number(error.details?.limit);
+    const tier = typeof error.details?.tier === 'string' ? error.details.tier : null;
+    if (Number.isFinite(limit) && tier) {
+      lines.push(`  ${paint('!', ANSI.yellow, color)} Your ${tier} plan allows ${limit} active API ${limit === 1 ? 'key' : 'keys'}.`);
+    }
+    const manageUrl = error.details?.manage_url || 'https://lixrl.com/profile/keys';
+    lines.push(
+      `  ${paint('→', ANSI.violet, color)} Revoke an unused key: ${manageUrl}`,
+      `  ${paint('→', ANSI.violet, color)} Then retry: ${error.details?.retry_command || 'lixrl login --open'}`,
+    );
+  }
+  if (error.requestId) lines.push(`  ${paint('Request', ANSI.dim, color)}  ${error.requestId}`);
+  return lines.join('\n');
+}
+
+export function listenForEnter({ input = process.stdin, open, url }) {
+  if (!input.isTTY || typeof open !== 'function') return () => {};
+  const onData = () => { Promise.resolve(open(url)).catch(() => {}); };
+  input.setEncoding?.('utf8');
+  input.once('data', onData);
+  input.resume?.();
+  return () => {
+    input.off?.('data', onData);
+    input.pause?.();
+  };
+}
 
 export function openBrowser(url) {
   const command = process.platform === 'darwin' ? 'open' : process.platform === 'win32' ? 'cmd' : 'xdg-open';
@@ -6,6 +88,17 @@ export function openBrowser(url) {
   const child = spawn(command, args, { detached: true, stdio: 'ignore' });
   child.on('error', () => {});
   child.unref();
+}
+
+export async function promptConfirm(label, { input = process.stdin, output = process.stderr } = {}) {
+  if (!input.isTTY || !output.isTTY) return false;
+  const prompt = createInterface({ input, output });
+  try {
+    const answer = await prompt.question(`${label} [y/N] `);
+    return /^y(?:es)?$/i.test(answer.trim());
+  } finally {
+    prompt.close();
+  }
 }
 
 export async function promptSecret(label = 'Lixrl API key: ') {

--- a/packages/lixrl-cli/tests/foundation.test.mjs
+++ b/packages/lixrl-cli/tests/foundation.test.mjs
@@ -46,6 +46,23 @@ test('client limits requests to the configured API and reports JSON errors', asy
   await assert.rejects(() => client.request('https://evil.example/api/urls'), ApiError);
 });
 
+test('client preserves actionable API error codes and details', async () => {
+  const client = new LixrlClient({
+    apiUrl: 'https://lixrl.com',
+    apiKey: `elu_${'a'.repeat(24)}`,
+    fetchImpl: async () => new Response(JSON.stringify({
+      error: 'API key limit reached (1 for free tier)',
+      code: 'api_key_limit_reached',
+      limit: 1,
+      tier: 'free',
+    }), { status: 403, headers: { 'content-type': 'application/json' } }),
+  });
+  await assert.rejects(
+    () => client.request('/api/keys', { method: 'POST', body: { name: 'CLI' } }),
+    (error) => error.code === 'api_key_limit_reached' && error.details.limit === 1,
+  );
+});
+
 test('JSON output redacts credential-shaped fields', () => {
   assert.doesNotMatch(safeJson({ apiKey: `elu_${'a'.repeat(24)}`, nested: { token: 'secret' } }), /elu_|secret/);
 });

--- a/packages/lixrl-cli/tests/ui.test.mjs
+++ b/packages/lixrl-cli/tests/ui.test.mjs
@@ -1,0 +1,39 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { colorEnabled, failureBlock, loginChallenge } from '../src/ui.js';
+
+test('device login displays the prefilled verification URL without requiring color', () => {
+  const output = loginChallenge({
+    url: 'https://accounts.elixpo.com/device?user_code=LIXR-L123',
+    code: 'LIXR-L123',
+    expiresInSeconds: 600,
+    profile: 'default',
+    interactive: true,
+  });
+  assert.match(output, /device\?user_code=LIXR-L123/);
+  assert.match(output, /Press Enter to open here/);
+  assert.match(output, /No localhost callback or exposed port is required/);
+  assert.doesNotMatch(output, /\u001b\[/);
+});
+
+test('NO_COLOR disables terminal styling', () => {
+  assert.equal(colorEnabled({ isTTY: true }, { NO_COLOR: '1', TERM: 'xterm' }), false);
+  assert.equal(colorEnabled({ isTTY: true }, { TERM: 'xterm' }), true);
+});
+
+test('key-limit errors include a concrete recovery path', () => {
+  const output = failureBlock({
+    code: 'api_key_limit_reached',
+    message: 'API key limit reached (1 for free tier)',
+    details: {
+      limit: 1,
+      tier: 'free',
+      manage_url: 'https://lixrl.com/profile/keys',
+      retry_command: 'lixrl login --open',
+    },
+  });
+  assert.match(output, /free plan allows 1 active API key/);
+  assert.match(output, /profile\/keys/);
+  assert.match(output, /lixrl login --open/);
+  assert.doesNotMatch(output, /\u001b\[/);
+});


### PR DESCRIPTION
## What this does

Makes device login match the compact LixBlogs terminal flow. The CLI now shows the prefilled Accounts URL, supports Enter-to-open, uses TTY-aware status colors, and replaces raw errors with actionable output.

## Why

Login previously printed two plain lines, and plan-limit failures did not tell users how to recover.

## Changes

- add compact login and approval cards with `NO_COLOR` support
- preserve Accounts code prefill and Enter-to-open behavior
- expose structured key-limit metadata from API routes
- offer to open key management and retry within the active login session
- add recovery hints while preserving JSON-safe errors
- update CLI and site documentation

## Verification

- `git diff --check` clean
- focused UI and API-error tests added
- Node/npm and `biome.sh` unavailable in this environment; CI must execute the suites

---
Fixes #63
