### PR TITLE
[ELIXPO] Fix CLI key-limit recovery

### DIFF
--- a/app/api/cli/auth/requests/[id]/token/route.ts
+++ b/app/api/cli/auth/requests/[id]/token/route.ts
@@ -50,7 +50,9 @@ export async function POST(
 
   const limits = TIER_LIMITS[row.tier];
   const keyCount = await db.prepare(
-    'SELECT COUNT(*) as count FROM api_keys WHERE user_id = ? AND is_active = 1',
+    `SELECT COUNT(*) as count FROM api_keys
+     WHERE user_id = ? AND is_active = 1
+     AND (expires_at IS NULL OR datetime(expires_at) > datetime('now'))`,
   ).bind(row.user_id).first<{ count: number }>();
   if ((keyCount?.count || 0) >= limits.maxApiKeys) {
     return NextResponse.json({

--- a/app/api/cli/auth/requests/route.ts
+++ b/app/api/cli/auth/requests/route.ts
@@ -32,7 +32,9 @@ export async function POST(request: NextRequest) {
   const db = getDB();
   const limits = TIER_LIMITS[user.tier];
   const keyCount = await db.prepare(
-    'SELECT COUNT(*) as count FROM api_keys WHERE user_id = ? AND is_active = 1',
+    `SELECT COUNT(*) as count FROM api_keys
+     WHERE user_id = ? AND is_active = 1
+     AND (expires_at IS NULL OR datetime(expires_at) > datetime('now'))`,
   ).bind(user.id).first<{ count: number }>();
   if ((keyCount?.count || 0) >= limits.maxApiKeys) {
     return NextResponse.json({

--- a/app/api/keys/route.ts
+++ b/app/api/keys/route.ts
@@ -31,7 +31,11 @@ export async function POST(request: NextRequest) {
   const resolvedScopes = scopes || 'read,write';
   if (!isValidScopes(resolvedScopes)) return badRequest('scopes must be "read" or "read,write"');
 
-  const keyCount = await db.prepare('SELECT COUNT(*) as count FROM api_keys WHERE user_id = ? AND is_active = 1')
+  const keyCount = await db.prepare(
+    `SELECT COUNT(*) as count FROM api_keys
+     WHERE user_id = ? AND is_active = 1
+     AND (expires_at IS NULL OR datetime(expires_at) > datetime('now'))`,
+  )
     .bind(user.id).first<{ count: number }>();
 
   if ((keyCount?.count || 0) >= limits.maxApiKeys) {

--- a/app/cli/authorize/page.tsx
+++ b/app/cli/authorize/page.tsx
@@ -45,7 +45,9 @@ export default async function AuthorizeCliPage({
   }
 
   const keyCount = await db.prepare(
-    'SELECT COUNT(*) as count FROM api_keys WHERE user_id = ? AND is_active = 1',
+    `SELECT COUNT(*) as count FROM api_keys
+     WHERE user_id = ? AND is_active = 1
+     AND (expires_at IS NULL OR datetime(expires_at) > datetime('now'))`,
   ).bind(user.id).first<{ count: number }>();
   const limits = TIER_LIMITS[user.tier];
 

--- a/app/components/Modal.tsx
+++ b/app/components/Modal.tsx
@@ -247,6 +247,7 @@ interface ConfirmDialogProps {
   /** "danger" turns the confirm button red — use for destructive actions */
   variant?: 'default' | 'danger';
   loading?: boolean;
+  error?: string;
 }
 
 export function ConfirmDialog({
@@ -259,6 +260,7 @@ export function ConfirmDialog({
   cancelLabel = 'Cancel',
   variant = 'default',
   loading = false,
+  error,
 }: ConfirmDialogProps) {
   const danger = variant === 'danger';
   return (
@@ -270,6 +272,14 @@ export function ConfirmDialog({
       size="sm"
       disableBackdropClose={loading}
     >
+      {error && (
+        <p
+          role="alert"
+          className="mb-4 rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm leading-5 text-red-700"
+        >
+          {error}
+        </p>
+      )}
       <div className="flex gap-2 justify-end">
         <button
           type="button"

--- a/app/dashboard/subscription/page.tsx
+++ b/app/dashboard/subscription/page.tsx
@@ -52,7 +52,11 @@ export default async function SubscriptionPage({
       .bind(user.id)
       .first<{ count: number }>(),
     db
-      .prepare('SELECT COUNT(*) as count FROM api_keys WHERE user_id = ? AND is_active = 1')
+      .prepare(
+        `SELECT COUNT(*) as count FROM api_keys
+         WHERE user_id = ? AND is_active = 1
+         AND (expires_at IS NULL OR datetime(expires_at) > datetime('now'))`,
+      )
       .bind(user.id)
       .first<{ count: number }>(),
   ]);

--- a/app/docs/cli/page.tsx
+++ b/app/docs/cli/page.tsx
@@ -133,6 +133,14 @@ lixrl --help`}</Command>
       <Command>{`lixrl login --open
 lixrl whoami`}</Command>
       <p className={P}>
+        Running <code className="font-mono">lixrl login</code> again reuses a
+        valid key already stored for the selected profile. Use{' '}
+        <code className="font-mono">lixrl login --force</code> only to rotate it.
+        The CLI cannot revoke account keys during device login; when the limit
+        is full, revoke one in the browser, wait for the **Revoked** status, and
+        then press Enter in the terminal.
+      </p>
+      <p className={P}>
         Read-only keys can list links, analytics, and exports without changing
         data. Read/write keys can also create, update, disable, and delete
         links. The approval screen shows the active-key allowance for your plan.

--- a/app/profile/keys/page.tsx
+++ b/app/profile/keys/page.tsx
@@ -45,6 +45,7 @@ export default function ApiKeysPage() {
   // Revoke confirm state
   const [revokeTarget, setRevokeTarget] = useState<ApiKey | null>(null);
   const [revoking, setRevoking] = useState(false);
+  const [revokeError, setRevokeError] = useState('');
 
   const fetchKeys = async () => {
     const res = await fetch('/api/keys');
@@ -86,11 +87,19 @@ export default function ApiKeysPage() {
 
   const handleRevokeConfirm = async () => {
     if (!revokeTarget) return;
+    setRevokeError('');
     setRevoking(true);
     try {
-      await fetch(`/api/keys/${revokeTarget.id}`, { method: 'DELETE' });
+      const response = await fetch(`/api/keys/${revokeTarget.id}`, { method: 'DELETE' });
+      const data = await response.json().catch(() => null);
+      if (!response.ok) {
+        setRevokeError(data?.error || 'The key could not be revoked. Refresh and try again.');
+        return;
+      }
       setRevokeTarget(null);
-      fetchKeys();
+      await fetchKeys();
+    } catch {
+      setRevokeError('Could not reach Lixrl. Check your connection and try again.');
     } finally {
       setRevoking(false);
     }
@@ -275,7 +284,10 @@ export default function ApiKeysPage() {
                   {k.is_active === 1 && (
                     <button
                       type="button"
-                      onClick={() => setRevokeTarget(k)}
+                      onClick={() => {
+                        setRevokeError('');
+                        setRevokeTarget(k);
+                      }}
                       className="text-xs text-white/55 hover:text-[#f87171] transition-colors px-2 py-1"
                       style={{ background: 'transparent', border: 'none' }}
                     >
@@ -475,13 +487,19 @@ export default function ApiKeysPage() {
       {/* ─────── Revoke confirm ─────── */}
       <ConfirmDialog
         open={!!revokeTarget}
-        onClose={() => !revoking && setRevokeTarget(null)}
+        onClose={() => {
+          if (!revoking) {
+            setRevokeError('');
+            setRevokeTarget(null);
+          }
+        }}
         onConfirm={handleRevokeConfirm}
         title={`Revoke "${revokeTarget?.name ?? ''}"?`}
         description="Any app using this key will lose access immediately. This cannot be undone."
         confirmLabel="Revoke key"
         variant="danger"
         loading={revoking}
+        error={revokeError}
       />
     </div>
   );

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -13,7 +13,11 @@ export default async function ProfilePage() {
 
   const [urlCount, keyCount, totalClicks, sessionCount] = await Promise.all([
     db.prepare('SELECT COUNT(*) as count FROM urls WHERE user_id = ?').bind(user.id).first<{ count: number }>(),
-    db.prepare('SELECT COUNT(*) as count FROM api_keys WHERE user_id = ? AND is_active = 1').bind(user.id).first<{ count: number }>(),
+    db.prepare(
+      `SELECT COUNT(*) as count FROM api_keys
+       WHERE user_id = ? AND is_active = 1
+       AND (expires_at IS NULL OR datetime(expires_at) > datetime('now'))`,
+    ).bind(user.id).first<{ count: number }>(),
     db.prepare('SELECT COUNT(*) as count FROM clicks c JOIN urls u ON c.url_id = u.id WHERE u.user_id = ? AND c.is_bot = 0')
       .bind(user.id).first<{ count: number }>(),
     db.prepare('SELECT COUNT(*) as count FROM sessions WHERE user_id = ? AND expires_at > datetime("now")')

--- a/packages/lixrl-cli/README.md
+++ b/packages/lixrl-cli/README.md
@@ -21,6 +21,8 @@ lixrl whoami
 
 The CLI displays a prefilled Accounts URL and one-time code. Press Enter to open it or use `--open` to launch it immediately. After identity approval, Lixrl asks you to choose the key name, read or read/write access, and an optional expiry date. If your plan has no free key slot, the CLI offers to open key management so you can revoke an unused key and retry without starting the Accounts login again. Passwords, browser cookies, and Accounts refresh tokens are never stored by the CLI.
 
+Running `lixrl login` again reuses a valid key already stored for the selected profile. Use `lixrl login --force` only when you intentionally want to rotate that key. The CLI cannot revoke account keys by itself during device login; if the active-key allowance is full, revoke one in the browser, wait until its status shows **Revoked**, and then press Enter in the terminal.
+
 ### Paste an existing key
 
 ```bash

--- a/packages/lixrl-cli/bin/shortner.mjs
+++ b/packages/lixrl-cli/bin/shortner.mjs
@@ -5,6 +5,7 @@ import { createRequire } from 'node:module';
 import { resolveConfig, ProfileRegistry, validateProfile } from '../src/config.js';
 import { CredentialStore, validateKey } from '../src/credentials.js';
 import { LixrlClient } from '../src/client.js';
+import { findValidLocalLogin } from '../src/login.js';
 import { emit, fail, EXIT_CODES } from '../src/contract.js';
 import {
   approvalChallenge,
@@ -13,6 +14,7 @@ import {
   loginChallenge,
   openBrowser,
   promptConfirm,
+  promptEnter,
   promptSecret,
   successLine,
 } from '../src/ui.js';
@@ -77,7 +79,7 @@ const OPTIONS = {
 const HELP = `lixrl — production CLI for Lixrl
 
 Usage:
-  lixrl login [--profile <name>] [--open]
+  lixrl login [--profile <name>] [--open] [--force]
   lixrl login --key [--profile <name>] [--open]
   lixrl logout [--profile <name>] --yes
   lixrl whoami [--profile <name>] [--json]
@@ -107,6 +109,7 @@ Global flags:
   --api-url <url>     API origin (default: https://lixrl.com)
   --open              open the Accounts approval page during device login
   --key               paste an existing Lixrl API key instead of device login
+  --force             rotate a valid local login instead of reusing it
   --json              stable machine-readable output
   --no-input          never prompt
   --quiet             suppress ordinary output
@@ -129,12 +132,34 @@ async function main(argv = process.argv.slice(2)) {
 
   if (command === 'login') {
     const directKeyLogin = options.key || Boolean(process.env.LIXRL_API_KEY);
+    let key;
+    let user;
+    const existing = await findValidLocalLogin({
+      credentials,
+      profile,
+      apiUrl: config.apiUrl,
+      force: options.force,
+      directKeyLogin,
+    });
+    if (existing) {
+      user = existing.user;
+      const loginResult = {
+        profile,
+        reused: true,
+        user: { email: user.email, display_name: user.display_name, tier: user.tier },
+      };
+      if (options.json) return emit(loginResult, options);
+      if (!options.quiet) {
+        process.stdout.write(`${successLine(`Already logged in as ${user.email} (${profile}).`, colorEnabled(process.stdout))}\n`);
+        process.stdout.write('  Use `lixrl login --force` only when you want to rotate this key.\n');
+      }
+      return undefined;
+    }
+
     if (options['no-input'] && !process.env.LIXRL_API_KEY) {
       throw Object.assign(new Error('Device login is interactive. Use lixrl login or provide LIXRL_API_KEY for --no-input.'), { code: 'login_required', exitCode: EXIT_CODES.AUTH });
     }
 
-    let key;
-    let user;
     if (directKeyLogin) {
       if (options.open) openBrowser(`${config.apiUrl}/profile/keys`);
       key = validateKey(process.env.LIXRL_API_KEY || await promptSecret('Paste Lixrl API key: '));
@@ -183,9 +208,9 @@ async function main(argv = process.argv.slice(2)) {
           if (!recoverable || !interactive) throw error;
 
           const manageUrl = error.details?.manage_url || `${config.apiUrl}/profile/keys`;
-          if (!await promptConfirm('API key limit reached. Open key settings to revoke one?')) throw error;
+          if (!await promptConfirm('The CLI cannot revoke account keys itself. Open key settings in your browser?')) throw error;
           openBrowser(manageUrl);
-          if (!await promptConfirm('After revoking an unused key, retry login now?')) throw error;
+          await promptEnter('Revoke an active key in the browser and wait until it shows “Revoked”. Then return here.');
           authorization = await startAuthorization();
         }
       } finally {
@@ -201,7 +226,11 @@ async function main(argv = process.argv.slice(2)) {
 
     if (!process.env.LIXRL_API_KEY) await credentials.set(profile, key);
     await registry.add(profile);
-    const loginResult = { profile, user: { email: user.email, display_name: user.display_name, tier: user.tier } };
+    const loginResult = {
+      profile,
+      reused: false,
+      user: { email: user.email, display_name: user.display_name, tier: user.tier },
+    };
     if (options.json) return emit(loginResult, options);
     if (!options.quiet) {
       process.stdout.write(`${successLine(`Logged in as ${user.email} (${profile}).`, colorEnabled(process.stdout))}\n`);

--- a/packages/lixrl-cli/src/login.js
+++ b/packages/lixrl-cli/src/login.js
@@ -1,0 +1,22 @@
+import { LixrlClient } from './client.js';
+
+export async function findValidLocalLogin({
+  credentials,
+  profile,
+  apiUrl,
+  force = false,
+  directKeyLogin = false,
+  Client = LixrlClient,
+}) {
+  if (force || directKeyLogin) return null;
+  const key = await credentials.get(profile);
+  if (!key) return null;
+
+  try {
+    const user = await new Client({ apiUrl, apiKey: key }).me();
+    return { user };
+  } catch (error) {
+    if (error?.code === 'login_required') return null;
+    throw error;
+  }
+}

--- a/packages/lixrl-cli/src/ui.js
+++ b/packages/lixrl-cli/src/ui.js
@@ -101,6 +101,17 @@ export async function promptConfirm(label, { input = process.stdin, output = pro
   }
 }
 
+export async function promptEnter(label, { input = process.stdin, output = process.stderr } = {}) {
+  if (!input.isTTY || !output.isTTY) return false;
+  const prompt = createInterface({ input, output });
+  try {
+    await prompt.question(`${label}\nPress Enter to retry.`);
+    return true;
+  } finally {
+    prompt.close();
+  }
+}
+
 export async function promptSecret(label = 'Lixrl API key: ') {
   if (!process.stdin.isTTY || !process.stdout.isTTY) {
     const chunks = [];

--- a/packages/lixrl-cli/tests/login.test.mjs
+++ b/packages/lixrl-cli/tests/login.test.mjs
@@ -1,0 +1,56 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { findValidLocalLogin } from '../src/login.js';
+
+const credentials = (key) => ({ get: async () => key });
+
+test('login reuses a valid local profile without starting device authorization', async () => {
+  const calls = [];
+  class Client {
+    constructor(options) {
+      calls.push(options);
+    }
+
+    async me() {
+      return { email: 'user@example.com', tier: 'free' };
+    }
+  }
+  const result = await findValidLocalLogin({
+    credentials: credentials(`elu_${'a'.repeat(24)}`),
+    profile: 'default',
+    apiUrl: 'https://lixrl.com',
+    Client,
+  });
+  assert.equal(result.user.email, 'user@example.com');
+  assert.equal(calls.length, 1);
+});
+
+test('forced login and direct-key login skip local-profile reuse', async () => {
+  const store = credentials(`elu_${'a'.repeat(24)}`);
+  assert.equal(await findValidLocalLogin({
+    credentials: store,
+    profile: 'default',
+    apiUrl: 'https://lixrl.com',
+    force: true,
+  }), null);
+  assert.equal(await findValidLocalLogin({
+    credentials: store,
+    profile: 'default',
+    apiUrl: 'https://lixrl.com',
+    directKeyLogin: true,
+  }), null);
+});
+
+test('an invalid stored key falls through to device login', async () => {
+  class Client {
+    async me() {
+      throw Object.assign(new Error('Unauthorized'), { code: 'login_required' });
+    }
+  }
+  assert.equal(await findValidLocalLogin({
+    credentials: credentials(`elu_${'a'.repeat(24)}`),
+    profile: 'default',
+    apiUrl: 'https://lixrl.com',
+    Client,
+  }), null);
+});


### PR DESCRIPTION
## What this does

Makes free-tier CLI login recover reliably when an API-key slot is occupied. It also reuses a valid local profile instead of starting device authorization again.

## Why

The revoke dialog hid failed DELETE responses, the CLI retry prompt could be confirmed before browser revocation, and expired keys still consumed active quota.

## Changes

- keep revoke failures visible in `/profile/keys`
- explain that revocation must happen in the browser and wait for Enter afterward
- validate and reuse the selected keychain profile by default
- add `lixrl login --force` for intentional rotation
- exclude expired keys from quota checks and usage displays
- document reuse and recovery behavior

## Verification

- `git diff --check` clean
- focused local-profile tests added
- Node/npm and `biome.sh` unavailable in this environment; CI must execute the suites

---
Fixes #67
