### PR TITLE
[ELIXPO] Validate CLI input before authentication

### DIFF
--- a/app/docs/cli/page.tsx
+++ b/app/docs/cli/page.tsx
@@ -191,6 +191,14 @@ lixrl urls create "https://example.com/article" \
   --title "Article" --tag automation --json --no-input`}</Command>
 
       <h2 id="links" className={H2}>Manage short links</h2>
+      <p className={P}>
+        Interactive output uses green for completed operations, purple for
+        status information, yellow for correctable input warnings, and red for
+        failures. Set <code className="font-mono">NO_COLOR=1</code> for plain
+        output. Commands and required flags are checked before authentication,
+        so a typo or missing <code className="font-mono">--file</code> is
+        reported without asking you to sign in.
+      </p>
       <Command>{`# Create
 lixrl urls create "https://example.com/launch" \
   --title "Launch" --campaign launch --tag release

--- a/packages/lixrl-cli/README.md
+++ b/packages/lixrl-cli/README.md
@@ -50,6 +50,8 @@ lixrl qr https://example.com --track --style aurora --output campaign.svg
 
 Deletion, API-key revocation, mapping removal, and file replacement require `--yes`. Use `--json --no-input` for automation.
 
+The interactive terminal uses distinct colors and symbols for successful operations, status information, correctable warnings, and failures. Set `NO_COLOR=1` for plain output. Command names, subcommands, required arguments, and required flags are validated before the CLI reads your keychain or asks you to sign in, so typos return an immediate usage message.
+
 ## Agent skills
 
 The npm package contains focused skills for link management and QR generation. They are not copied anywhere during installation.

--- a/packages/lixrl-cli/bin/shortner.mjs
+++ b/packages/lixrl-cli/bin/shortner.mjs
@@ -6,6 +6,7 @@ import { resolveConfig, ProfileRegistry, validateProfile } from '../src/config.j
 import { CredentialStore, validateKey } from '../src/credentials.js';
 import { LixrlClient } from '../src/client.js';
 import { findValidLocalLogin } from '../src/login.js';
+import { validateInvocation } from '../src/invocation.js';
 import { emit, fail, EXIT_CODES } from '../src/contract.js';
 import {
   approvalChallenge,
@@ -19,7 +20,7 @@ import {
   successLine,
 } from '../src/ui.js';
 import { runDomains, runKeys, runUrls } from '../src/commands.js';
-import { qrRequiresLogin, runQr } from '../src/qr.js';
+import { qrRequiresLogin, runQr, validateQrInvocation } from '../src/qr.js';
 import { runSkills } from '../src/skills.js';
 import {
   AccountsDeviceAuth,
@@ -119,11 +120,21 @@ Global flags:
 `;
 
 async function main(argv = process.argv.slice(2)) {
-  const parsed = parseArgs({ args: argv, options: OPTIONS, allowPositionals: true, strict: false });
+  let parsed;
+  try {
+    parsed = parseArgs({ args: argv, options: OPTIONS, allowPositionals: true, strict: true });
+  } catch (error) {
+    throw Object.assign(new Error(error?.message || 'Invalid command options.'), {
+      code: 'invalid_usage',
+      exitCode: EXIT_CODES.USAGE,
+    });
+  }
   const options = parsed.values;
   const [command, subcommand, ...args] = parsed.positionals;
   if (options.version) return process.stdout.write(`${VERSION}\n`);
   if (options.help || !command) return process.stdout.write(HELP);
+  validateInvocation(command, subcommand, args, options);
+  if (command === 'qr') validateQrInvocation(subcommand, options);
 
   const config = resolveConfig({ options });
   const registry = new ProfileRegistry();
@@ -241,12 +252,12 @@ async function main(argv = process.argv.slice(2)) {
 
   if (command === 'profiles') {
     const state = await registry.read();
-    return emit({ active: state.active, profiles: state.profiles }, options);
+    return emit({ active: state.active, profiles: state.profiles }, options, 'Profiles loaded');
   }
   if (command === 'use') {
     if (!subcommand) throw Object.assign(new Error('Usage: lixrl use <profile>'), { exitCode: EXIT_CODES.USAGE });
     await registry.use(subcommand);
-    return emit({ active: subcommand }, options);
+    return emit({ active: subcommand }, options, 'Active profile changed');
   }
   if (command === 'skills') return runSkills(subcommand, args, options);
 
@@ -261,11 +272,11 @@ async function main(argv = process.argv.slice(2)) {
     if (!options.yes) throw Object.assign(new Error('Logging out requires --yes.'), { code: 'confirmation_required', exitCode: EXIT_CODES.CONFIRMATION });
     if (!process.env.LIXRL_API_KEY) await credentials.delete(profile);
     await registry.remove(profile);
-    return emit({ loggedOut: true, profile }, options);
+    return emit({ loggedOut: true, profile }, options, 'Logged out');
   }
   if (command === 'whoami') {
     const user = await new LixrlClient({ apiUrl: config.apiUrl, apiKey: key }).me();
-    return emit({ profile, ...user }, options);
+    return emit({ profile, ...user }, options, 'Account verified');
   }
   const client = new LixrlClient({ apiUrl: config.apiUrl, apiKey: key });
   if (command === 'qr') return runQr(client, subcommand, options);

--- a/packages/lixrl-cli/src/commands.js
+++ b/packages/lixrl-cli/src/commands.js
@@ -47,7 +47,7 @@ function urlInput(destination, options) {
   return body;
 }
 
-async function writeResponse(response, output, options) {
+async function writeResponse(response, output, options, message) {
   const content = Buffer.from(await response.arrayBuffer());
   if (!output) {
     process.stdout.write(content);
@@ -57,7 +57,7 @@ async function writeResponse(response, output, options) {
     usage(`Refusing to overwrite ${output}. Pass --force --yes to replace it.`);
   }
   await writeFile(output, content);
-  emit({ output, bytes: content.byteLength }, options);
+  emit({ output, bytes: content.byteLength }, options, message);
 }
 
 export async function runUrls(client, action, args, options) {
@@ -66,11 +66,11 @@ export async function runUrls(client, action, args, options) {
     case 'list':
       return emit(await client.request(query('/api/urls', {
         limit: positive(options.limit, 50), offset: positive(options.offset, 0), search: options.search,
-      })), options);
+      })), options, 'Links loaded');
     case 'get':
-      return emit(await client.request(`/api/urls/${pathPart(code)}`), options);
+      return emit(await client.request(`/api/urls/${pathPart(code)}`), options, 'Link loaded');
     case 'create':
-      return emit(await client.request('/api/urls', { method: 'POST', body: urlInput(code, options) }), options);
+      return emit(await client.request('/api/urls', { method: 'POST', body: urlInput(code, options) }), options, 'Short link created');
     case 'update': {
       required(code, 'Usage: lixrl urls update <code> [options]');
       const body = {
@@ -85,36 +85,36 @@ export async function runUrls(client, action, args, options) {
         ...(options['clear-expiry'] ? { expires_at: null } : {}),
       };
       if (!Object.keys(body).length) usage('Provide at least one field to update.');
-      return emit(await client.request(`/api/urls/${pathPart(code)}`, { method: 'PATCH', body }), options);
+      return emit(await client.request(`/api/urls/${pathPart(code)}`, { method: 'PATCH', body }), options, 'Link updated');
     }
     case 'enable':
     case 'disable':
       return emit(await client.request(`/api/urls/${pathPart(code)}`, {
         method: 'PATCH', body: { is_active: action === 'enable' },
-      }), options);
+      }), options, action === 'enable' ? 'Link enabled' : 'Link disabled');
     case 'delete':
       requireConfirmation(options, `Deleting ${required(code, 'Usage: lixrl urls delete <code> --yes')}`);
-      return emit(await client.request(`/api/urls/${pathPart(code)}`, { method: 'DELETE' }), options);
+      return emit(await client.request(`/api/urls/${pathPart(code)}`, { method: 'DELETE' }), options, 'Link deleted');
     case 'bulk-create': { // JSON array or {"links": [...]}
       const file = required(options.file, 'Usage: lixrl urls bulk-create --file <links.json>');
       const input = JSON.parse(await readFile(file, 'utf8'));
       const links = Array.isArray(input) ? input : input.links;
       if (!Array.isArray(links)) usage('Bulk input must be an array or an object containing a links array.');
-      return emit(await client.request('/api/urls/bulk-create', { method: 'POST', body: { links } }), options);
+      return emit(await client.request('/api/urls/bulk-create', { method: 'POST', body: { links } }), options, 'Links created');
     }
     case 'bulk-delete':
       requireConfirmation(options, 'Bulk deletion');
       if (!args.length) usage('Usage: lixrl urls bulk-delete <code...> --yes');
-      return emit(await client.request('/api/urls/bulk-delete', { method: 'POST', body: { codes: args } }), options);
+      return emit(await client.request('/api/urls/bulk-delete', { method: 'POST', body: { codes: args } }), options, 'Links deleted');
     case 'analytics':
-      return emit(await client.request(query(`/api/urls/${pathPart(code)}/analytics`, { days: positive(options.days, 7) })), options);
+      return emit(await client.request(query(`/api/urls/${pathPart(code)}/analytics`, { days: positive(options.days, 7) })), options, 'Analytics loaded');
     case 'export': {
       const response = await client.request('/api/urls/export.csv', { raw: true });
-      return writeResponse(response, options.output, options);
+      return writeResponse(response, options.output, options, 'Links exported');
     }
     case 'export-clicks': {
       const response = await client.request(`/api/urls/${pathPart(code)}/clicks.csv`, { raw: true });
-      return writeResponse(response, options.output, options);
+      return writeResponse(response, options.output, options, 'Clicks exported');
     }
     default:
       usage('Usage: lixrl urls <list|get|create|update|enable|disable|delete|bulk-create|bulk-delete|analytics|export|export-clicks>');
@@ -124,7 +124,7 @@ export async function runUrls(client, action, args, options) {
 export async function runKeys(client, action, args, options) {
   switch (action) {
     case 'list':
-      return emit(await client.request('/api/keys'), options);
+      return emit(await client.request('/api/keys'), options, 'API keys loaded');
     case 'create':
       return emit(await client.request('/api/keys', {
         method: 'POST',
@@ -133,10 +133,10 @@ export async function runKeys(client, action, args, options) {
           scopes: options.scopes || 'read,write',
           ...(options.expires ? { expires_at: options.expires } : {}),
         },
-      }), options);
+      }), options, 'API key created');
     case 'revoke':
       requireConfirmation(options, 'Revoking an API key');
-      return emit(await client.request(`/api/keys/${pathPart(args[0])}`, { method: 'DELETE' }), options);
+      return emit(await client.request(`/api/keys/${pathPart(args[0])}`, { method: 'DELETE' }), options, 'API key revoked');
     default:
       usage('Usage: lixrl keys <list|create|revoke>');
   }
@@ -146,20 +146,20 @@ export async function runDomains(client, action, args, options) {
   const id = args[0];
   switch (action) {
     case 'list':
-      return emit(await client.request('/api/subdomains'), options);
+      return emit(await client.request('/api/subdomains'), options, 'Subdomains loaded');
     case 'claim':
       return emit(await client.request('/api/subdomains', {
         method: 'POST', body: { label: required(id, 'Usage: lixrl domains claim <label>') },
-      }), options);
+      }), options, 'Subdomain claimed');
     case 'verify':
-      return emit(await client.request(`/api/subdomains/${pathPart(id)}/verify`, { method: 'POST', body: {} }), options);
+      return emit(await client.request(`/api/subdomains/${pathPart(id)}/verify`, { method: 'POST', body: {} }), options, 'Subdomain verified');
     case 'default':
-      return emit(await client.request(`/api/subdomains/${pathPart(id)}`, { method: 'PATCH', body: { is_default: true } }), options);
+      return emit(await client.request(`/api/subdomains/${pathPart(id)}`, { method: 'PATCH', body: { is_default: true } }), options, 'Default subdomain changed');
     case 'remove':
       requireConfirmation(options, 'Removing a subdomain');
-      return emit(await client.request(`/api/subdomains/${pathPart(id)}`, { method: 'DELETE' }), options);
+      return emit(await client.request(`/api/subdomains/${pathPart(id)}`, { method: 'DELETE' }), options, 'Subdomain removed');
     case 'links':
-      return emit(await client.request(`/api/subdomains/${pathPart(id)}/links`), options);
+      return emit(await client.request(`/api/subdomains/${pathPart(id)}/links`), options, 'Subdomain links loaded');
     case 'map':
       return emit(await client.request(`/api/subdomains/${pathPart(id)}/links`, {
         method: 'POST',
@@ -167,10 +167,10 @@ export async function runDomains(client, action, args, options) {
           url_code: required(args[1], 'Usage: lixrl domains map <id> <url-code> [--slug <branded-code>]'),
           ...(options.slug ? { short_code: options.slug } : {}),
         },
-      }), options);
+      }), options, 'Link mapped');
     case 'unmap':
       requireConfirmation(options, 'Removing a subdomain link mapping');
-      return emit(await client.request(`/api/subdomains/${pathPart(id)}/links/${pathPart(args[1])}`, { method: 'DELETE' }), options);
+      return emit(await client.request(`/api/subdomains/${pathPart(id)}/links/${pathPart(args[1])}`, { method: 'DELETE' }), options, 'Link mapping removed');
     default:
       usage('Usage: lixrl domains <list|claim|verify|default|remove|links|map|unmap>');
   }

--- a/packages/lixrl-cli/src/contract.js
+++ b/packages/lixrl-cli/src/contract.js
@@ -1,4 +1,4 @@
-import { colorEnabled, failureBlock } from './ui.js';
+import { colorEnabled, failureBlock, successLine } from './ui.js';
 
 export const EXIT_CODES = Object.freeze({ OK: 0, ERROR: 1, USAGE: 2, AUTH: 4, CONFIRMATION: 5 });
 
@@ -15,9 +15,13 @@ export function requireConfirmation(options, action) {
   }
 }
 
-export function emit(value, options = {}) {
+export function emit(value, options = {}, message = 'Done') {
   if (options.json) process.stdout.write(`${safeJson({ ok: true, data: value })}\n`);
-  else if (!options.quiet) process.stdout.write(`${format(value)}\n`);
+  else if (!options.quiet) {
+    process.stdout.write(`${successLine(message, colorEnabled(process.stdout))}\n`);
+    const details = format(value);
+    if (details) process.stdout.write(`${details}\n`);
+  }
 }
 
 export function fail(error, options = {}) {

--- a/packages/lixrl-cli/src/invocation.js
+++ b/packages/lixrl-cli/src/invocation.js
@@ -1,0 +1,100 @@
+import { EXIT_CODES } from './contract.js';
+
+const URL_COMMANDS = new Set(['url', 'urls', 'links']);
+const KEY_COMMANDS = new Set(['key', 'keys']);
+const DOMAIN_COMMANDS = new Set(['domain', 'domains', 'subdomains']);
+const TOP_LEVEL_COMMANDS = new Set([
+  'login', 'logout', 'whoami', 'profiles', 'use', 'skills', 'qr',
+  ...URL_COMMANDS, ...KEY_COMMANDS, ...DOMAIN_COMMANDS,
+]);
+
+function usage(message, code = 'invalid_usage') {
+  const exitCode = code === 'confirmation_required' ? EXIT_CODES.CONFIRMATION : EXIT_CODES.USAGE;
+  throw Object.assign(new Error(message), { code, exitCode });
+}
+
+function requireValue(value, message) {
+  if (!value) usage(message);
+}
+
+function requireConfirmation(options, message) {
+  if (!options.yes) usage(message, 'confirmation_required');
+}
+
+function validateUrls(action, args, options) {
+  const resourceActions = new Set(['get', 'delete', 'enable', 'disable', 'analytics', 'export-clicks']);
+  if (action === 'list' || action === 'export') return;
+  if (action === 'create') return requireValue(args[0], 'Usage: lixrl urls create <destination> [options]');
+  if (resourceActions.has(action)) {
+    requireValue(args[0], `Usage: lixrl urls ${action} <code>${action === 'delete' ? ' --yes' : ''}`);
+    if (action === 'delete') requireConfirmation(options, 'Deleting a link requires --yes.');
+    return;
+  }
+  if (action === 'update') {
+    requireValue(args[0], 'Usage: lixrl urls update <code> [options]');
+    const fields = [
+      options.destination, options.title, options['clear-title'], options.campaign,
+      options['clear-campaign'], options.tag?.length, options['clear-tags'],
+      options.expires, options['clear-expiry'],
+    ];
+    if (!fields.some(Boolean)) usage('Provide at least one field to update.');
+    return;
+  }
+  if (action === 'bulk-create') return requireValue(options.file, 'Usage: lixrl urls bulk-create --file <links.json>');
+  if (action === 'bulk-delete') {
+    requireValue(args[0], 'Usage: lixrl urls bulk-delete <code...> --yes');
+    requireConfirmation(options, 'Bulk deletion requires --yes.');
+    return;
+  }
+  usage('Usage: lixrl urls <list|get|create|update|enable|disable|delete|bulk-create|bulk-delete|analytics|export|export-clicks>');
+}
+
+function validateKeys(action, args, options) {
+  if (action === 'list') return;
+  if (action === 'create') return requireValue(options.name, 'Usage: lixrl keys create --name <name> [--scopes read|read,write]');
+  if (action === 'revoke') {
+    requireValue(args[0], 'Usage: lixrl keys revoke <id> --yes');
+    requireConfirmation(options, 'Revoking an API key requires --yes.');
+    return;
+  }
+  usage('Usage: lixrl keys <list|create|revoke>');
+}
+
+function validateDomains(action, args, options) {
+  if (action === 'list') return;
+  if (['claim', 'verify', 'default', 'remove', 'links'].includes(action)) {
+    requireValue(args[0], `Usage: lixrl domains ${action} <id>${action === 'remove' ? ' --yes' : ''}`);
+    if (action === 'remove') requireConfirmation(options, 'Removing a subdomain requires --yes.');
+    return;
+  }
+  if (action === 'map' || action === 'unmap') {
+    requireValue(args[0], `Usage: lixrl domains ${action} <id> <url-code>${action === 'unmap' ? ' --yes' : ''}`);
+    requireValue(args[1], `Usage: lixrl domains ${action} <id> <url-code>${action === 'unmap' ? ' --yes' : ''}`);
+    if (action === 'unmap') requireConfirmation(options, 'Removing a subdomain link mapping requires --yes.');
+    return;
+  }
+  usage('Usage: lixrl domains <list|claim|verify|default|remove|links|map|unmap>');
+}
+
+export function validateInvocation(command, subcommand, args = [], options = {}) {
+  if (!TOP_LEVEL_COMMANDS.has(command)) {
+    usage(`Unknown command "${command}". Run lixrl --help.`, 'unknown_command');
+  }
+  if (URL_COMMANDS.has(command)) return validateUrls(subcommand, args, options);
+  if (KEY_COMMANDS.has(command)) return validateKeys(subcommand, args, options);
+  if (DOMAIN_COMMANDS.has(command)) return validateDomains(subcommand, args, options);
+  if (command === 'qr') return requireValue(subcommand, 'Usage: lixrl qr <destination> [options]');
+  if (command === 'use') {
+    requireValue(subcommand, 'Usage: lixrl use <profile>');
+    if (args.length) usage('Usage: lixrl use <profile>');
+    return;
+  }
+  if (command === 'skills') {
+    if (subcommand === 'list') return;
+    if (subcommand === 'inspect' || subcommand === 'install') {
+      return requireValue(args[0], `Usage: lixrl skills ${subcommand} <name>`);
+    }
+    usage('Usage: lixrl skills <list|inspect|install> [name]');
+  }
+  if (subcommand || args.length) usage(`Usage: lixrl ${command}`);
+}

--- a/packages/lixrl-cli/src/qr.js
+++ b/packages/lixrl-cli/src/qr.js
@@ -44,10 +44,23 @@ export function qrRequiresLogin(options = {}) {
   return !!options.track || !!options.logo || PRESETS.findIndex(([id]) => id === style) > 2;
 }
 
-export async function runQr(client, destination, options) {
+export function validateQrInvocation(destination, options = {}) {
   const presetIndex = PRESETS.findIndex(([id]) => id === (options.style || 'rounded'));
   if (presetIndex < 0) invalid(`Unknown QR style. Choose: ${PRESETS.map(([id]) => id).join(', ')}.`);
-  let data = normalizeUrl(destination);
+  const data = normalizeUrl(destination);
+  const format = (options.format || 'svg').toLowerCase().replace('jpg', 'jpeg');
+  if (!['svg', 'png', 'jpeg'].includes(format)) invalid('QR format must be svg, png, jpg, or jpeg.');
+  const size = Number(options.size || 1024);
+  if (!Number.isSafeInteger(size) || size < 128 || size > 4096) invalid('QR size must be an integer from 128 to 4096 pixels.');
+  const output = options.output || `lixrl-qr.${format === 'jpeg' ? 'jpg' : format}`;
+  if (existsSync(output) && !(options.force && options.yes)) invalid(`Refusing to overwrite ${output}. Pass --force --yes to replace it.`);
+  return { presetIndex, data, format, size, output };
+}
+
+export async function runQr(client, destination, options) {
+  const validated = validateQrInvocation(destination, options);
+  const { presetIndex, format, size, output } = validated;
+  let { data } = validated;
   if (qrRequiresLogin(options)) {
     if (!client) throw Object.assign(new Error('This QR option requires login. Run lixrl login.'), { code: 'login_required', exitCode: 4 });
     const account = await client.me();
@@ -61,13 +74,6 @@ export async function runQr(client, destination, options) {
       data = tracked.short_url;
     }
   }
-
-  const format = (options.format || 'svg').toLowerCase().replace('jpg', 'jpeg');
-  if (!['svg', 'png', 'jpeg'].includes(format)) invalid('QR format must be svg, png, jpg, or jpeg.');
-  const size = Number(options.size || 1024);
-  if (!Number.isSafeInteger(size) || size < 128 || size > 4096) invalid('QR size must be an integer from 128 to 4096 pixels.');
-  const output = options.output || `lixrl-qr.${format === 'jpeg' ? 'jpg' : format}`;
-  if (existsSync(output) && !(options.force && options.yes)) invalid(`Refusing to overwrite ${output}. Pass --force --yes to replace it.`);
 
   const [{ default: QRCodeStyling }, { JSDOM }, nodeCanvas] = await Promise.all([
     import('qr-code-styling'), import('jsdom'), import('@napi-rs/canvas'),
@@ -87,7 +93,7 @@ export async function runQr(client, destination, options) {
   const rendered = await qr.getRawData(format);
   if (!rendered) throw new Error('QR renderer returned no data.');
   await writeFile(output, Buffer.from(rendered));
-  emit({ output, format, style: PRESETS[presetIndex][0], size, data, tracked: !!options.track }, options);
+  emit({ output, format, style: PRESETS[presetIndex][0], size, data, tracked: !!options.track }, options, 'QR code saved');
 }
 
 export const QR_STYLES = PRESETS.map(([id]) => id);

--- a/packages/lixrl-cli/src/skills.js
+++ b/packages/lixrl-cli/src/skills.js
@@ -9,7 +9,7 @@ const bundled = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../s
 
 export async function runSkills(action, args, options) {
   const names = (await readdir(bundled, { withFileTypes: true })).filter((entry) => entry.isDirectory()).map((entry) => entry.name).sort();
-  if (action === 'list') return emit({ skills: names }, options);
+  if (action === 'list') return emit({ skills: names }, options, 'Bundled skills loaded');
   const name = args[0];
   if (!name || !names.includes(name)) {
     throw Object.assign(new Error(`Choose a bundled skill: ${names.join(', ')}.`), { code: 'invalid_skill', exitCode: EXIT_CODES.USAGE });
@@ -30,7 +30,7 @@ export async function runSkills(action, args, options) {
     }
     await mkdir(root, { recursive: true });
     await cp(path.join(bundled, name), target, { recursive: true, force: true });
-    return emit({ installed: name, target }, options);
+    return emit({ installed: name, target }, options, 'Skill installed');
   }
   throw Object.assign(new Error('Usage: lixrl skills <list|inspect|install> [name]'), { exitCode: EXIT_CODES.USAGE });
 }

--- a/packages/lixrl-cli/src/ui.js
+++ b/packages/lixrl-cli/src/ui.js
@@ -19,6 +19,18 @@ function paint(value, code, enabled) {
   return enabled ? `${code}${value}${ANSI.reset}` : value;
 }
 
+const STATUS = Object.freeze({
+  success: ['✓', ANSI.green],
+  info: ['→', ANSI.violet],
+  warning: ['!', ANSI.yellow],
+  error: ['✘', ANSI.red],
+});
+
+export function statusLine(status, message, color = false) {
+  const [symbol, shade] = STATUS[status] || STATUS.info;
+  return `  ${paint(symbol, shade, color)} ${status === 'error' ? paint(message, ANSI.bold, color) : message}`;
+}
+
 export function loginChallenge({ url, code, expiresInSeconds, profile, interactive, color = false }) {
   const instruction = interactive
     ? 'Press Enter to open here, or use the URL on another device.'
@@ -49,11 +61,24 @@ export function approvalChallenge({ url, color = false }) {
 }
 
 export function successLine(message, color = false) {
-  return `  ${paint('✓', ANSI.green, color)} ${message}`;
+  return statusLine('success', message, color);
+}
+
+export function infoLine(message, color = false) {
+  return statusLine('info', message, color);
+}
+
+export function warningLine(message, color = false) {
+  return statusLine('warning', message, color);
+}
+
+export function errorLine(message, color = false) {
+  return statusLine('error', message, color);
 }
 
 export function failureBlock(error, color = false) {
-  const lines = [`  ${paint('✘', ANSI.red, color)} ${paint(error.message, ANSI.bold, color)}`];
+  const warning = ['confirmation_required', 'invalid_usage', 'login_required'].includes(error.code);
+  const lines = [statusLine(warning ? 'warning' : 'error', error.message, color)];
   if (error.code === 'api_key_limit_reached' || error.code === 'key_limit_reached') {
     const limit = Number(error.details?.limit);
     const tier = typeof error.details?.tier === 'string' ? error.details.tier : null;

--- a/packages/lixrl-cli/tests/invocation.test.mjs
+++ b/packages/lixrl-cli/tests/invocation.test.mjs
@@ -1,0 +1,30 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { validateInvocation } from '../src/invocation.js';
+
+test('unknown commands fail before credential lookup', () => {
+  assert.throws(
+    () => validateInvocation('ursl', undefined, [], {}),
+    (error) => error.code === 'unknown_command' && /Unknown command "ursl"/.test(error.message),
+  );
+});
+
+test('bulk creation requires --file before credential lookup', () => {
+  assert.throws(
+    () => validateInvocation('urls', 'bulk-create', [], {}),
+    (error) => error.code === 'invalid_usage' && /--file/.test(error.message),
+  );
+});
+
+test('destructive confirmation is validated before credential lookup', () => {
+  assert.throws(
+    () => validateInvocation('urls', 'delete', ['abc123'], {}),
+    (error) => error.code === 'confirmation_required' && error.exitCode === 5 && /--yes/.test(error.message),
+  );
+});
+
+test('valid commands pass preflight validation', () => {
+  assert.equal(validateInvocation('urls', 'bulk-create', [], { file: 'links.json' }), undefined);
+  assert.equal(validateInvocation('qr', 'https://example.com', [], {}), undefined);
+  assert.equal(validateInvocation('whoami', undefined, [], {}), undefined);
+});

--- a/packages/lixrl-cli/tests/ui.test.mjs
+++ b/packages/lixrl-cli/tests/ui.test.mjs
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { colorEnabled, failureBlock, loginChallenge } from '../src/ui.js';
+import { colorEnabled, failureBlock, loginChallenge, statusLine } from '../src/ui.js';
 
 test('device login displays the prefilled verification URL without requiring color', () => {
   const output = loginChallenge({
@@ -19,6 +19,21 @@ test('device login displays the prefilled verification URL without requiring col
 test('NO_COLOR disables terminal styling', () => {
   assert.equal(colorEnabled({ isTTY: true }, { NO_COLOR: '1', TERM: 'xterm' }), false);
   assert.equal(colorEnabled({ isTTY: true }, { TERM: 'xterm' }), true);
+});
+
+test('terminal statuses use distinct symbols and colors', () => {
+  assert.match(statusLine('success', 'Created', true), /✓.*Created/);
+  assert.match(statusLine('info', 'Loading', true), /→.*Loading/);
+  assert.match(statusLine('warning', 'Check input', true), /!.*Check input/);
+  assert.match(statusLine('error', 'Failed', true), /✘.*Failed/);
+  assert.notEqual(statusLine('success', 'Created', true), statusLine('error', 'Created', true));
+  assert.doesNotMatch(statusLine('success', 'Created', false), /\u001b\[/);
+});
+
+test('correctable input failures render as warnings', () => {
+  const output = failureBlock({ code: 'invalid_usage', message: 'Missing --file.' }, true);
+  assert.match(output, /!.*Missing --file/);
+  assert.doesNotMatch(output, /✘/);
 });
 
 test('key-limit errors include a concrete recovery path', () => {


### PR DESCRIPTION
## What this does

Validates CLI intent before authentication and gives interactive commands consistent, status-aware terminal output. Typos and missing flags now report the actual input problem instead of `login_required`.

## Why

Unknown commands and incomplete operations previously reached keychain lookup first, which obscured mistakes for logged-out users.

## Changes

- validate commands, subcommands, operands, flags, and confirmations before auth
- reject unknown options through strict argument parsing
- validate paid QR arguments before credential lookup
- add distinct success, info, warning, and error output styles
- add command-specific completion messages
- preserve JSON, quiet, non-TTY, and `NO_COLOR` behavior

## Verification

- `git diff --check` clean
- focused invocation and terminal-style tests added
- Node/npm and `biome.sh` unavailable in this environment; CI must execute the suites

---
Fixes #69
