### PR TITLE
[ELIXPO] Show async CLI loading status

### DIFF
--- a/app/docs/cli/page.tsx
+++ b/app/docs/cli/page.tsx
@@ -197,7 +197,9 @@ lixrl urls create "https://example.com/article" \
         failures. Set <code className="font-mono">NO_COLOR=1</code> for plain
         output. Commands and required flags are checked before authentication,
         so a typo or missing <code className="font-mono">--file</code> is
-        reported without asking you to sign in.
+        reported without asking you to sign in. A compact spinner appears only
+        while network, approval, keychain, or QR work is pending; JSON, quiet,
+        and piped output never receive spinner frames.
       </p>
       <Command>{`# Create
 lixrl urls create "https://example.com/launch" \

--- a/packages/lixrl-cli/README.md
+++ b/packages/lixrl-cli/README.md
@@ -52,6 +52,8 @@ Deletion, API-key revocation, mapping removal, and file replacement require `--y
 
 The interactive terminal uses distinct colors and symbols for successful operations, status information, correctable warnings, and failures. Set `NO_COLOR=1` for plain output. Command names, subcommands, required arguments, and required flags are validated before the CLI reads your keychain or asks you to sign in, so typos return an immediate usage message.
 
+Network requests, browser approvals, keychain writes, and QR rendering show a compact spinner only while that asynchronous operation is pending. Spinner frames are cleared before the final result and are never emitted by `--json`, `--quiet`, or non-interactive output.
+
 ## Agent skills
 
 The npm package contains focused skills for link management and QR generation. They are not copied anywhere during installation.

--- a/packages/lixrl-cli/bin/shortner.mjs
+++ b/packages/lixrl-cli/bin/shortner.mjs
@@ -18,6 +18,7 @@ import {
   promptEnter,
   promptSecret,
   successLine,
+  withSpinner,
 } from '../src/ui.js';
 import { runDomains, runKeys, runUrls } from '../src/commands.js';
 import { qrRequiresLogin, runQr, validateQrInvocation } from '../src/qr.js';
@@ -32,6 +33,14 @@ import {
 
 const require = createRequire(import.meta.url);
 const VERSION = require('../package.json').version;
+
+function withLoadingClient(client, message, loading) {
+  return {
+    request: (...args) => loading(message, () => client.request(...args)),
+    me: () => loading(message, () => client.me()),
+  };
+}
+
 const OPTIONS = {
   profile: { type: 'string' },
   'api-url': { type: 'string' },
@@ -135,6 +144,7 @@ async function main(argv = process.argv.slice(2)) {
   if (options.help || !command) return process.stdout.write(HELP);
   validateInvocation(command, subcommand, args, options);
   if (command === 'qr') validateQrInvocation(subcommand, options);
+  const loading = (message, task) => withSpinner(message, task, options);
 
   const config = resolveConfig({ options });
   const registry = new ProfileRegistry();
@@ -145,13 +155,13 @@ async function main(argv = process.argv.slice(2)) {
     const directKeyLogin = options.key || Boolean(process.env.LIXRL_API_KEY);
     let key;
     let user;
-    const existing = await findValidLocalLogin({
+    const existing = await loading('Checking local profile', () => findValidLocalLogin({
       credentials,
       profile,
       apiUrl: config.apiUrl,
       force: options.force,
       directKeyLogin,
-    });
+    }));
     if (existing) {
       user = existing.user;
       const loginResult = {
@@ -174,17 +184,21 @@ async function main(argv = process.argv.slice(2)) {
     if (directKeyLogin) {
       if (options.open) openBrowser(`${config.apiUrl}/profile/keys`);
       key = validateKey(process.env.LIXRL_API_KEY || await promptSecret('Paste Lixrl API key: '));
-      user = await new LixrlClient({ apiUrl: config.apiUrl, apiKey: key }).me();
+      user = await loading('Verifying API key', () => (
+        new LixrlClient({ apiUrl: config.apiUrl, apiKey: key }).me()
+      ));
     } else {
       const progress = !options.quiet && !options.json;
       const color = colorEnabled(process.stderr);
-      const deviceConfig = await fetchLixrlCliConfig({ apiUrl: config.apiUrl });
+      const deviceConfig = await loading('Connecting to Lixrl', () => (
+        fetchLixrlCliConfig({ apiUrl: config.apiUrl })
+      ));
       const auth = new AccountsDeviceAuth({
         accountsUrl: options['accounts-url'] || deviceConfig.accountsUrl,
         clientId: options['client-id'] || deviceConfig.clientId,
         audience: deviceConfig.audience,
       });
-      const challenge = await auth.requestDeviceCode();
+      const challenge = await loading('Starting device login', () => auth.requestDeviceCode());
       const approvalUrl = challenge.verificationUriComplete || challenge.verificationUri;
       if (progress) process.stderr.write(`${loginChallenge({
         url: approvalUrl,
@@ -201,16 +215,18 @@ async function main(argv = process.argv.slice(2)) {
       }
       let token;
       try {
-        token = await waitForDeviceApproval(auth, challenge);
+        token = await loading('Waiting for browser approval', () => waitForDeviceApproval(auth, challenge));
       } finally {
         stopListening();
       }
       let authorization;
       try {
-        const startAuthorization = () => startLixrlAuthorization({
-          apiUrl: config.apiUrl,
-          accessToken: token.accessToken,
-        });
+        const startAuthorization = () => loading('Preparing key approval', () => (
+          startLixrlAuthorization({
+            apiUrl: config.apiUrl,
+            accessToken: token.accessToken,
+          })
+        ));
         try {
           authorization = await startAuthorization();
         } catch (error) {
@@ -230,12 +246,16 @@ async function main(argv = process.argv.slice(2)) {
       }
       if (progress) process.stderr.write(`${approvalChallenge({ url: authorization.approvalUrl, color })}\n`);
       if (options.open) openBrowser(authorization.approvalUrl);
-      const result = await waitForLixrlApproval(config.apiUrl, authorization);
+      const result = await loading('Waiting for key approval', () => (
+        waitForLixrlApproval(config.apiUrl, authorization)
+      ));
       key = validateKey(result.key);
       user = result.user;
     }
 
-    if (!process.env.LIXRL_API_KEY) await credentials.set(profile, key);
+    if (!process.env.LIXRL_API_KEY) {
+      await loading('Saving credentials', () => credentials.set(profile, key));
+    }
     await registry.add(profile);
     const loginResult = {
       profile,
@@ -262,10 +282,10 @@ async function main(argv = process.argv.slice(2)) {
   if (command === 'skills') return runSkills(subcommand, args, options);
 
   if (command === 'qr' && !qrRequiresLogin(options)) {
-    return runQr(null, subcommand, options);
+    return runQr(null, subcommand, options, (task) => loading('Generating QR code', task));
   }
 
-  const key = await credentials.get(profile);
+  const key = await loading('Reading local credentials', () => credentials.get(profile));
   if (!key) throw Object.assign(new Error(`Profile "${profile}" is not logged in. Run lixrl login.`), { code: 'login_required', exitCode: EXIT_CODES.AUTH });
 
   if (command === 'logout') {
@@ -275,14 +295,29 @@ async function main(argv = process.argv.slice(2)) {
     return emit({ loggedOut: true, profile }, options, 'Logged out');
   }
   if (command === 'whoami') {
-    const user = await new LixrlClient({ apiUrl: config.apiUrl, apiKey: key }).me();
+    const user = await loading('Checking account', () => (
+      new LixrlClient({ apiUrl: config.apiUrl, apiKey: key }).me()
+    ));
     return emit({ profile, ...user }, options, 'Account verified');
   }
   const client = new LixrlClient({ apiUrl: config.apiUrl, apiKey: key });
-  if (command === 'qr') return runQr(client, subcommand, options);
-  if (['url', 'urls', 'links'].includes(command)) return runUrls(client, subcommand, args, options);
-  if (['key', 'keys'].includes(command)) return runKeys(client, subcommand, args, options);
-  if (['domain', 'domains', 'subdomains'].includes(command)) return runDomains(client, subcommand, args, options);
+  if (command === 'qr') {
+    return runQr(
+      withLoadingClient(client, options.track ? 'Creating tracked QR link' : 'Checking QR access', loading),
+      subcommand,
+      options,
+      (task) => loading('Generating QR code', task),
+    );
+  }
+  if (['url', 'urls', 'links'].includes(command)) {
+    return runUrls(withLoadingClient(client, 'Working with links', loading), subcommand, args, options);
+  }
+  if (['key', 'keys'].includes(command)) {
+    return runKeys(withLoadingClient(client, 'Working with API keys', loading), subcommand, args, options);
+  }
+  if (['domain', 'domains', 'subdomains'].includes(command)) {
+    return runDomains(withLoadingClient(client, 'Working with subdomains', loading), subcommand, args, options);
+  }
 
   throw Object.assign(new Error(`Unknown command: ${command}`), { code: 'unknown_command', exitCode: EXIT_CODES.USAGE });
 }

--- a/packages/lixrl-cli/src/qr.js
+++ b/packages/lixrl-cli/src/qr.js
@@ -57,7 +57,7 @@ export function validateQrInvocation(destination, options = {}) {
   return { presetIndex, data, format, size, output };
 }
 
-export async function runQr(client, destination, options) {
+export async function runQr(client, destination, options, renderTask = (task) => task()) {
   const validated = validateQrInvocation(destination, options);
   const { presetIndex, format, size, output } = validated;
   let { data } = validated;
@@ -75,24 +75,26 @@ export async function runQr(client, destination, options) {
     }
   }
 
-  const [{ default: QRCodeStyling }, { JSDOM }, nodeCanvas] = await Promise.all([
-    import('qr-code-styling'), import('jsdom'), import('@napi-rs/canvas'),
-  ]);
-  const [, dotsType, squareType, dotType, paint, background] = PRESETS[presetIndex];
-  const corner = paint.gradient ? paint.gradient.colorStops[0].color : paint.color;
-  const qr = new QRCodeStyling({
-    width: size, height: size, type: format === 'svg' ? 'svg' : 'canvas', data, margin: 8,
-    jsdom: JSDOM, nodeCanvas, image: await logoData(options.logo),
-    qrOptions: { errorCorrectionLevel: 'H' },
-    dotsOptions: { type: dotsType, ...paint },
-    cornersSquareOptions: { type: squareType, color: corner },
-    cornersDotOptions: { type: dotType, color: corner },
-    backgroundOptions: { color: background },
-    imageOptions: { margin: 6, imageSize: 0.4, hideBackgroundDots: true, saveAsBlob: true },
+  await renderTask(async () => {
+    const [{ default: QRCodeStyling }, { JSDOM }, nodeCanvas] = await Promise.all([
+      import('qr-code-styling'), import('jsdom'), import('@napi-rs/canvas'),
+    ]);
+    const [, dotsType, squareType, dotType, paint, background] = PRESETS[presetIndex];
+    const corner = paint.gradient ? paint.gradient.colorStops[0].color : paint.color;
+    const qr = new QRCodeStyling({
+      width: size, height: size, type: format === 'svg' ? 'svg' : 'canvas', data, margin: 8,
+      jsdom: JSDOM, nodeCanvas, image: await logoData(options.logo),
+      qrOptions: { errorCorrectionLevel: 'H' },
+      dotsOptions: { type: dotsType, ...paint },
+      cornersSquareOptions: { type: squareType, color: corner },
+      cornersDotOptions: { type: dotType, color: corner },
+      backgroundOptions: { color: background },
+      imageOptions: { margin: 6, imageSize: 0.4, hideBackgroundDots: true, saveAsBlob: true },
+    });
+    const rendered = await qr.getRawData(format);
+    if (!rendered) throw new Error('QR renderer returned no data.');
+    await writeFile(output, Buffer.from(rendered));
   });
-  const rendered = await qr.getRawData(format);
-  if (!rendered) throw new Error('QR renderer returned no data.');
-  await writeFile(output, Buffer.from(rendered));
   emit({ output, format, style: PRESETS[presetIndex][0], size, data, tracked: !!options.track }, options, 'QR code saved');
 }
 

--- a/packages/lixrl-cli/src/ui.js
+++ b/packages/lixrl-cli/src/ui.js
@@ -26,6 +26,8 @@ const STATUS = Object.freeze({
   error: ['✘', ANSI.red],
 });
 
+const SPINNER_FRAMES = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
+
 export function statusLine(status, message, color = false) {
   const [symbol, shade] = STATUS[status] || STATUS.info;
   return `  ${paint(symbol, shade, color)} ${status === 'error' ? paint(message, ANSI.bold, color) : message}`;
@@ -74,6 +76,33 @@ export function warningLine(message, color = false) {
 
 export function errorLine(message, color = false) {
   return statusLine('error', message, color);
+}
+
+export async function withSpinner(message, task, {
+  quiet = false,
+  json = false,
+  stream = process.stderr,
+  env = process.env,
+  intervalMs = 80,
+} = {}) {
+  if (quiet || json || !stream.isTTY) return task();
+
+  const color = colorEnabled(stream, env);
+  let frame = 0;
+  const render = () => {
+    const symbol = paint(SPINNER_FRAMES[frame % SPINNER_FRAMES.length], ANSI.violet, color);
+    stream.write(`\r  ${symbol} ${message}…`);
+    frame += 1;
+  };
+  render();
+  const timer = setInterval(render, intervalMs);
+  timer.unref?.();
+  try {
+    return await task();
+  } finally {
+    clearInterval(timer);
+    stream.write('\r\u001b[2K');
+  }
 }
 
 export function failureBlock(error, color = false) {

--- a/packages/lixrl-cli/tests/ui.test.mjs
+++ b/packages/lixrl-cli/tests/ui.test.mjs
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { colorEnabled, failureBlock, loginChallenge, statusLine } from '../src/ui.js';
+import { colorEnabled, failureBlock, loginChallenge, statusLine, withSpinner } from '../src/ui.js';
 
 test('device login displays the prefilled verification URL without requiring color', () => {
   const output = loginChallenge({
@@ -34,6 +34,48 @@ test('correctable input failures render as warnings', () => {
   const output = failureBlock({ code: 'invalid_usage', message: 'Missing --file.' }, true);
   assert.match(output, /!.*Missing --file/);
   assert.doesNotMatch(output, /✘/);
+});
+
+test('spinner is visible only while an interactive task is pending', async () => {
+  let output = '';
+  const stream = { isTTY: true, write: (value) => { output += value; } };
+  let release;
+  const pending = new Promise((resolve) => { release = resolve; });
+  const task = withSpinner('Loading links', () => pending, {
+    stream,
+    env: { TERM: 'xterm' },
+    intervalMs: 10_000,
+  });
+  assert.match(output, /Loading links/);
+  release('done');
+  assert.equal(await task, 'done');
+  assert.match(output, /\u001b\[2K/);
+});
+
+test('spinner stays silent for JSON and non-TTY output', async () => {
+  let output = '';
+  const stream = { isTTY: true, write: (value) => { output += value; } };
+  assert.equal(await withSpinner('Loading', async () => 42, { stream, json: true }), 42);
+  assert.equal(output, '');
+
+  const piped = { isTTY: false, write: (value) => { output += value; } };
+  assert.equal(await withSpinner('Loading', async () => 43, { stream: piped }), 43);
+  assert.equal(output, '');
+});
+
+test('spinner clears its line when an asynchronous task fails', async () => {
+  let output = '';
+  const stream = { isTTY: true, write: (value) => { output += value; } };
+  await assert.rejects(
+    () => withSpinner('Loading', async () => { throw new Error('failed'); }, {
+      stream,
+      env: { NO_COLOR: '1', TERM: 'xterm' },
+      intervalMs: 10_000,
+    }),
+    /failed/,
+  );
+  assert.match(output, /Loading/);
+  assert.match(output, /\u001b\[2K/);
 });
 
 test('key-limit errors include a concrete recovery path', () => {


### PR DESCRIPTION
## What this does

Shows a compact animated status while the CLI is genuinely waiting on asynchronous work. The spinner clears before the final result, so success and error messages remain readable.

## Why

Network requests, device approvals, keychain access, and QR rendering previously appeared idle while pending.

## Changes

- add a TTY-aware asynchronous spinner with guaranteed cleanup
- show focused loading labels for auth, links, keys, domains, and QR work
- isolate spinner boundaries from final result rendering
- suppress animation for JSON, quiet, and non-TTY output
- respect `NO_COLOR` and document the behavior
- test pending, successful, failed, and suppressed states

## Verification

- `git diff --check` clean
- Node/npm and `biome.sh` unavailable in this environment; CI must execute the added tests

---
Fixes #71
