### PR TITLE
fix: make CLI login resilient and selectable

### DIFF
--- a/app/docs/cli/page.tsx
+++ b/app/docs/cli/page.tsx
@@ -117,7 +117,8 @@ lixrl --help`}</Command>
 
       <h2 id="sign-in" className={H2}>Sign in and authenticate</h2>
       <p className={P}>
-        Choose browser-based device login for everyday use or paste a key you
+        Login first reuses a valid key already stored for the selected profile.
+        Otherwise, choose browser-based device login or paste a raw key you
         already created. Both paths store the final Lixrl key in your
         operating-system keychain; passwords and browser cookies never enter
         the CLI.
@@ -125,17 +126,20 @@ lixrl --help`}</Command>
 
       <h3 id="device-login" className={H3}>Recommended: Accounts device login</h3>
       <ol className="mb-5 list-decimal space-y-2 pl-6 text-[0.96rem] leading-7 text-[#555]">
-        <li>Run the command. The CLI displays a prefilled official Accounts URL and one-time code.</li>
+        <li>Run the command and choose whether to create a new key or paste an existing key.</li>
+        <li>For a new key, the CLI displays a prefilled official Accounts URL and one-time code.</li>
         <li>Press Enter to open the URL, or use <code className="font-mono">--open</code> to launch it immediately.</li>
         <li>The CLI opens a Lixrl approval page where you choose the key name, read or read/write access, and an optional expiry.</li>
         <li>Lixrl enforces your plan&apos;s key limit, delivers the key directly to the waiting CLI, and stores only its hash.</li>
       </ol>
-      <Command>{`lixrl login --open
+      <Command>{`lixrl login
+lixrl login --new-key --open
 lixrl whoami`}</Command>
       <p className={P}>
         Running <code className="font-mono">lixrl login</code> again reuses a
         valid key already stored for the selected profile. Use{' '}
-        <code className="font-mono">lixrl login --force</code> only to rotate it.
+        <code className="font-mono">lixrl login --new-key</code> only when you
+        intentionally want another key.
         The CLI cannot revoke account keys during device login; when the limit
         is full, revoke one in the browser, wait for the **Revoked** status, and
         then press Enter in the terminal.
@@ -157,15 +161,22 @@ lixrl whoami`}</Command>
       <p className={P}>
         If you or an administrator already created a restricted key under{' '}
         <Link href="/profile/keys" className="font-semibold text-[#c62828]">
-          Profile → API Keys
-        </Link>, paste it through the masked prompt:
+        Profile → API Keys
+        </Link>, choose option 2 during login or paste it through the masked prompt:
       </p>
       <Command>{`lixrl login --key
 lixrl whoami`}</Command>
       <Note>
         Never place an <code className="font-mono">elu_…</code> key in a URL,
-        source file, generated article, issue, or chat message.
+        source file, generated article, issue, or chat message. Lixrl stores
+        only the key hash, so a dashboard row cannot reveal the raw value later.
       </Note>
+      <p className={P}>
+        The CLI briefly retries transient login configuration and discovery
+        failures. Persistent errors identify whether Lixrl configuration,
+        Accounts timeout, network/DNS/TLS access, an HTTP response, or
+        incompatible authorization metadata caused the failure.
+      </p>
 
       <h3 id="profiles" className={H3}>Multiple accounts</h3>
       <Command>{`lixrl login --profile work --open

--- a/packages/lixrl-cli/README.md
+++ b/packages/lixrl-cli/README.md
@@ -8,20 +8,20 @@ lixrl login --open
 lixrl whoami
 ```
 
-Device login opens Elixpo Accounts, asks Lixrl to create a scoped API key, and stores that key in the operating-system keychain. The Accounts tokens used during approval remain in memory and are revoked after the exchange.
+If the selected profile already has a valid local key, login reuses it. Otherwise, the CLI asks whether to create a scoped key through Elixpo Accounts or paste an existing raw key. The final key is stored in the operating-system keychain. Accounts tokens used during approval remain in memory and are revoked after the exchange.
 
 ## Sign in securely
 
 ### Browser and device flow
 
 ```bash
-lixrl login --open
+lixrl login
 lixrl whoami
 ```
 
-The CLI displays a prefilled Accounts URL and one-time code. Press Enter to open it or use `--open` to launch it immediately. After identity approval, Lixrl asks you to choose the key name, read or read/write access, and an optional expiry date. If your plan has no free key slot, the CLI offers to open key management so you can revoke an unused key and retry without starting the Accounts login again. Passwords, browser cookies, and Accounts refresh tokens are never stored by the CLI.
+When no valid local key exists, choose **Create a new API key** to continue with Accounts device login, or choose **Use an existing API key** to paste a raw key into the masked prompt. Use `lixrl login --new-key --open` to skip the choice and intentionally create a key. The CLI displays a prefilled Accounts URL and one-time code. After identity approval, Lixrl asks you to choose the key name, access level, and optional expiry date. Passwords, browser cookies, and Accounts refresh tokens are never stored by the CLI.
 
-Running `lixrl login` again reuses a valid key already stored for the selected profile. Use `lixrl login --force` only when you intentionally want to rotate that key. The CLI cannot revoke account keys by itself during device login; if the active-key allowance is full, revoke one in the browser, wait until its status shows **Revoked**, and then press Enter in the terminal.
+Running `lixrl login` again reuses a valid key already stored for the selected profile. Use `lixrl login --new-key` only when you intentionally want another key. The CLI cannot recover raw values for keys shown in the dashboard because Lixrl stores only hashes; paste the original key value or create a new one. The CLI also cannot revoke account keys during device login. If the allowance is full, revoke one in the browser, wait until its status shows **Revoked**, and then press Enter in the terminal.
 
 ### Paste an existing key
 
@@ -29,7 +29,9 @@ Running `lixrl login` again reuses a valid key already stored for the selected p
 lixrl login --key
 ```
 
-Create the key at [lixrl.com/profile/keys](https://lixrl.com/profile/keys), then paste it into the masked prompt. This path is useful when an administrator has already issued a restricted key.
+Create the key at [lixrl.com/profile/keys](https://lixrl.com/profile/keys), then paste its original value into the masked prompt. You can also run plain `lixrl login` and choose option 2. Dashboard key rows cannot reveal a raw key after creation.
+
+Login configuration and Accounts discovery are retried briefly when a network or server failure is transient. If login still fails, the CLI distinguishes Lixrl configuration failures, Accounts timeouts, connection/DNS/TLS failures, HTTP failures, and incompatible authorization metadata instead of reporting every case as an Accounts outage.
 
 For CI, set `LIXRL_API_KEY` through the CI secret store and use `--json --no-input`; never place the key in source files, command arguments, generated content, or logs.
 

--- a/packages/lixrl-cli/bin/shortner.mjs
+++ b/packages/lixrl-cli/bin/shortner.mjs
@@ -16,6 +16,7 @@ import {
   openBrowser,
   promptConfirm,
   promptEnter,
+  promptLoginMethod,
   promptSecret,
   successLine,
   withSpinner,
@@ -49,6 +50,7 @@ const OPTIONS = {
   'no-input': { type: 'boolean', default: false },
   open: { type: 'boolean', default: false },
   key: { type: 'boolean', default: false },
+  'new-key': { type: 'boolean', default: false },
   'accounts-url': { type: 'string' },
   'client-id': { type: 'string' },
   yes: { type: 'boolean', short: 'y', default: false },
@@ -89,7 +91,8 @@ const OPTIONS = {
 const HELP = `lixrl — production CLI for Lixrl
 
 Usage:
-  lixrl login [--profile <name>] [--open] [--force]
+  lixrl login [--profile <name>] [--open]
+  lixrl login --new-key [--profile <name>] [--open]
   lixrl login --key [--profile <name>] [--open]
   lixrl logout [--profile <name>] --yes
   lixrl whoami [--profile <name>] [--json]
@@ -110,15 +113,15 @@ Usage:
   lixrl skills list|inspect|install [name]
 
 Authentication:
-  lixrl login uses Elixpo Accounts device authorization, asks Lixrl to create a
-  scoped key, and stores it in the OS keychain. Use --key to paste an existing
-  key into the masked prompt. CI should provide LIXRL_API_KEY instead.
+  lixrl login reuses a valid local key or asks whether to create a new key with
+  Elixpo Accounts or paste an existing key. CI should provide LIXRL_API_KEY.
 
 Global flags:
   --profile <name>    select a stored account
   --api-url <url>     API origin (default: https://lixrl.com)
   --open              open the Accounts approval page during device login
   --key               paste an existing Lixrl API key instead of device login
+  --new-key           create a new key even when a valid local key exists
   --force             rotate a valid local login instead of reusing it
   --json              stable machine-readable output
   --no-input          never prompt
@@ -152,14 +155,14 @@ async function main(argv = process.argv.slice(2)) {
   const profile = options.profile ? validateProfile(options.profile) : await registry.selected(config.profile);
 
   if (command === 'login') {
-    const directKeyLogin = options.key || Boolean(process.env.LIXRL_API_KEY);
+    let directKeyLogin = options.key || (!options['new-key'] && Boolean(process.env.LIXRL_API_KEY));
     let key;
     let user;
     const existing = await loading('Checking local profile', () => findValidLocalLogin({
       credentials,
       profile,
       apiUrl: config.apiUrl,
-      force: options.force,
+      force: options.force || options['new-key'],
       directKeyLogin,
     }));
     if (existing) {
@@ -177,8 +180,12 @@ async function main(argv = process.argv.slice(2)) {
       return undefined;
     }
 
-    if (options['no-input'] && !process.env.LIXRL_API_KEY) {
+    if (options['no-input'] && !directKeyLogin) {
       throw Object.assign(new Error('Device login is interactive. Use lixrl login or provide LIXRL_API_KEY for --no-input.'), { code: 'login_required', exitCode: EXIT_CODES.AUTH });
+    }
+
+    if (!directKeyLogin && !options['new-key'] && process.stdin.isTTY && process.stderr.isTTY) {
+      directKeyLogin = await promptLoginMethod() === 'existing';
     }
 
     if (directKeyLogin) {

--- a/packages/lixrl-cli/src/device-auth.js
+++ b/packages/lixrl-cli/src/device-auth.js
@@ -3,6 +3,7 @@ const DEFAULT_ACCOUNTS_URL = 'https://accounts.elixpo.com';
 const DEFAULT_CLIENT_ID = 'lixrl-cli-prod';
 const DEFAULT_AUDIENCE = 'lixrl.com';
 const DEFAULT_TIMEOUT_MS = 15_000;
+const DEFAULT_RETRIES = 2;
 
 const SAFE_ERRORS = {
   access_denied: 'Login was denied.',
@@ -11,11 +12,21 @@ const SAFE_ERRORS = {
   invalid_scope: 'The requested Accounts permissions are not available.',
   slow_down: 'Accounts requested slower polling.',
   temporarily_unavailable: 'Elixpo Accounts is temporarily unavailable.',
+  accounts_timeout: 'Elixpo Accounts did not respond in time. Check your connection and retry.',
+  accounts_unreachable: 'Could not reach Elixpo Accounts. Check your network, DNS, or TLS connection and retry.',
+  accounts_http_error: 'Elixpo Accounts returned an HTTP error. Retry shortly.',
+  invalid_accounts_response: 'Elixpo Accounts returned an invalid authorization response. Upgrade the CLI or retry.',
+  invalid_accounts_metadata: 'Elixpo Accounts returned incompatible authorization metadata. Upgrade the CLI or retry.',
+  lixrl_config_unavailable: 'Could not load Lixrl login configuration. Check your connection to lixrl.com and retry.',
+  unsupported_device_flow: 'Elixpo Accounts does not advertise the required device login flow.',
+  untrusted_accounts_endpoint: 'Elixpo Accounts returned an untrusted authorization endpoint.',
+  unsafe_accounts_origin: 'The configured Accounts origin must use HTTPS.',
 };
 
 export class DeviceAuthError extends Error {
   constructor(code = 'authentication_failed', status = 0) {
-    super(SAFE_ERRORS[code] || 'Device authorization failed.');
+    const statusSuffix = status && code === 'accounts_http_error' ? ` (HTTP ${status})` : '';
+    super(`${SAFE_ERRORS[code] || 'Device authorization failed.'}${statusSuffix}`);
     this.name = 'DeviceAuthError';
     this.code = code;
     this.status = status;
@@ -32,10 +43,47 @@ function trustedBase(value) {
   return url.toString().replace(/\/$/, '');
 }
 
-async function json(response) {
+async function json(response, invalidCode = 'temporarily_unavailable') {
   const payload = await response.json().catch(() => null);
-  if (!payload || typeof payload !== 'object') throw new DeviceAuthError('temporarily_unavailable', response.status);
+  if (!payload || typeof payload !== 'object') throw new DeviceAuthError(invalidCode, response.status);
   return payload;
+}
+
+async function requestWithRetry(fetchImpl, url, options, {
+  timeoutMs,
+  retries,
+  sleep,
+  timeoutCode,
+  networkCode,
+}) {
+  let attempt = 0;
+  while (attempt <= retries) {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), timeoutMs);
+    try {
+      const response = await fetchImpl(url, {
+        ...options,
+        signal: options.signal || controller.signal,
+        headers: { accept: 'application/json', ...options.headers },
+      });
+      if (response.status >= 500 && attempt < retries) {
+        attempt += 1;
+        await sleep(150 * attempt);
+        continue;
+      }
+      return response;
+    } catch (error) {
+      if (attempt >= retries) {
+        const timedOut = controller.signal.aborted || error?.name === 'AbortError';
+        throw new DeviceAuthError(timedOut ? timeoutCode : networkCode);
+      }
+      attempt += 1;
+      await sleep(150 * attempt);
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+  throw new DeviceAuthError(networkCode);
 }
 
 export class AccountsDeviceAuth {
@@ -45,6 +93,8 @@ export class AccountsDeviceAuth {
     audience = DEFAULT_AUDIENCE,
     fetchImpl = globalThis.fetch,
     timeoutMs = DEFAULT_TIMEOUT_MS,
+    retries = DEFAULT_RETRIES,
+    sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
     env = process.env,
   } = {}) {
     if (typeof fetchImpl !== 'function') throw new TypeError('A fetch implementation is required.');
@@ -53,32 +103,27 @@ export class AccountsDeviceAuth {
     this.audience = audience;
     this.fetchImpl = fetchImpl;
     this.timeoutMs = timeoutMs;
+    this.retries = retries;
+    this.sleep = sleep;
     this.metadata = null;
   }
 
-  async fetch(url, options = {}) {
-    const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), this.timeoutMs);
-    try {
-      return await this.fetchImpl(url, {
-        ...options,
-        signal: options.signal || controller.signal,
-        headers: { accept: 'application/json', ...options.headers },
-      });
-    } catch {
-      throw new DeviceAuthError('temporarily_unavailable');
-    } finally {
-      clearTimeout(timeout);
-    }
+  async fetch(url, options = {}, { retry = false } = {}) {
+    return requestWithRetry(this.fetchImpl, url, options, {
+      timeoutMs: this.timeoutMs,
+      retries: retry ? this.retries : 0,
+      sleep: this.sleep,
+      timeoutCode: 'accounts_timeout',
+      networkCode: 'accounts_unreachable',
+    });
   }
 
   async discover() {
     if (this.metadata) return this.metadata;
-    const response = await this.fetch(`${this.accountsUrl}/.well-known/oauth-authorization-server`);
-    const payload = await json(response);
-    if (!response.ok || payload.issuer !== this.accountsUrl) {
-      throw new DeviceAuthError('temporarily_unavailable', response.status);
-    }
+    const response = await this.fetch(`${this.accountsUrl}/.well-known/oauth-authorization-server`, {}, { retry: true });
+    if (!response.ok) throw new DeviceAuthError('accounts_http_error', response.status);
+    const payload = await json(response, 'invalid_accounts_metadata');
+    if (payload.issuer !== this.accountsUrl) throw new DeviceAuthError('invalid_accounts_metadata', response.status);
     if (!payload.grant_types_supported?.includes(DEVICE_GRANT)) {
       throw new DeviceAuthError('unsupported_device_flow');
     }
@@ -104,10 +149,13 @@ export class AccountsDeviceAuth {
         scope: scopes.join(' '),
       }),
     });
-    const payload = await json(response);
-    if (!response.ok) throw new DeviceAuthError(payload.error, response.status);
+    const payload = await json(response, 'invalid_accounts_response');
+    if (!response.ok) {
+      if (response.status >= 500) throw new DeviceAuthError('accounts_http_error', response.status);
+      throw new DeviceAuthError(payload.error, response.status);
+    }
     if (!payload.device_code || !payload.user_code || !payload.verification_uri) {
-      throw new DeviceAuthError('temporarily_unavailable', response.status);
+      throw new DeviceAuthError('invalid_accounts_response', response.status);
     }
     return {
       deviceCode: payload.device_code,
@@ -130,13 +178,14 @@ export class AccountsDeviceAuth {
         client_id: this.clientId,
       }),
     });
-    const payload = await json(response);
+    const payload = await json(response, 'invalid_accounts_response');
     if (response.ok) {
-      if (!payload.access_token || !payload.refresh_token) throw new DeviceAuthError('temporarily_unavailable');
+      if (!payload.access_token || !payload.refresh_token) throw new DeviceAuthError('invalid_accounts_response');
       return { status: 'approved', accessToken: payload.access_token, refreshToken: payload.refresh_token };
     }
     if (payload.error === 'authorization_pending') return { status: 'pending' };
     if (payload.error === 'slow_down') return { status: 'slow_down' };
+    if (response.status >= 500) throw new DeviceAuthError('accounts_http_error', response.status);
     throw new DeviceAuthError(payload.error, response.status);
   }
 
@@ -170,12 +219,24 @@ function lixrlTarget(apiUrl, pathname) {
   return target;
 }
 
-export async function fetchLixrlCliConfig({ apiUrl, fetchImpl = globalThis.fetch }) {
+export async function fetchLixrlCliConfig({
+  apiUrl,
+  fetchImpl = globalThis.fetch,
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+  retries = DEFAULT_RETRIES,
+  sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+}) {
   const target = lixrlTarget(apiUrl, '/api/cli/config');
-  const response = await fetchImpl(target, { headers: { accept: 'application/json' } });
-  const payload = await json(response);
+  const response = await requestWithRetry(fetchImpl, target, {}, {
+    timeoutMs,
+    retries,
+    sleep,
+    timeoutCode: 'lixrl_config_unavailable',
+    networkCode: 'lixrl_config_unavailable',
+  });
+  if (!response.ok) throw new DeviceAuthError('lixrl_config_unavailable', response.status);
+  const payload = await json(response, 'lixrl_config_unavailable');
   if (
-    !response.ok ||
     typeof payload.client_id !== 'string' ||
     !payload.client_id.trim() ||
     typeof payload.accounts_origin !== 'string' ||

--- a/packages/lixrl-cli/src/invocation.js
+++ b/packages/lixrl-cli/src/invocation.js
@@ -84,6 +84,11 @@ export function validateInvocation(command, subcommand, args = [], options = {})
   if (KEY_COMMANDS.has(command)) return validateKeys(subcommand, args, options);
   if (DOMAIN_COMMANDS.has(command)) return validateDomains(subcommand, args, options);
   if (command === 'qr') return requireValue(subcommand, 'Usage: lixrl qr <destination> [options]');
+  if (command === 'login') {
+    if (options.key && options['new-key']) usage('Choose either --key or --new-key, not both.');
+    if (subcommand || args.length) usage('Usage: lixrl login [--key | --new-key] [--profile <name>]');
+    return;
+  }
   if (command === 'use') {
     requireValue(subcommand, 'Usage: lixrl use <profile>');
     if (args.length) usage('Usage: lixrl use <profile>');

--- a/packages/lixrl-cli/src/ui.js
+++ b/packages/lixrl-cli/src/ui.js
@@ -166,6 +166,35 @@ export async function promptEnter(label, { input = process.stdin, output = proce
   }
 }
 
+export function parseLoginChoice(value) {
+  const choice = String(value || '').trim().toLowerCase();
+  if (!choice || ['1', 'new', 'create'].includes(choice)) return 'new';
+  if (['2', 'existing', 'key', 'paste'].includes(choice)) return 'existing';
+  return null;
+}
+
+export async function promptLoginMethod({ input = process.stdin, output = process.stderr } = {}) {
+  if (!input.isTTY || !output.isTTY) return 'new';
+  const color = colorEnabled(output);
+  const prompt = createInterface({ input, output });
+  try {
+    output.write([
+      '',
+      `  ${paint('◆', ANSI.violet, color)} ${paint('Choose how to sign in', ANSI.bold, color)}`,
+      '  1. Create a new API key (recommended)',
+      '  2. Use an existing API key (paste the raw key)',
+      '',
+    ].join('\n'));
+    while (true) {
+      const choice = parseLoginChoice(await prompt.question('  Choose [1]: '));
+      if (choice) return choice;
+      output.write(`${warningLine('Enter 1 to create a key or 2 to paste an existing key.', color)}\n`);
+    }
+  } finally {
+    prompt.close();
+  }
+}
+
 export async function promptSecret(label = 'Lixrl API key: ') {
   if (!process.stdin.isTTY || !process.stdout.isTTY) {
     const chunks = [];

--- a/packages/lixrl-cli/tests/device-auth.test.mjs
+++ b/packages/lixrl-cli/tests/device-auth.test.mjs
@@ -92,6 +92,61 @@ test('device login discovers its public OAuth configuration from Lixrl', async (
   });
 });
 
+test('Accounts discovery retries a transient network failure', async () => {
+  let calls = 0;
+  const auth = new AccountsDeviceAuth({
+    retries: 1,
+    sleep: async () => {},
+    fetchImpl: async () => {
+      calls += 1;
+      if (calls === 1) throw new TypeError('fetch failed');
+      return response(discovery);
+    },
+  });
+  assert.equal((await auth.discover()).issuer, 'https://accounts.elixpo.com');
+  assert.equal(calls, 2);
+});
+
+test('Accounts discovery reports network failures without a misleading outage message', async () => {
+  const auth = new AccountsDeviceAuth({
+    retries: 1,
+    sleep: async () => {},
+    fetchImpl: async () => { throw new TypeError('fetch failed'); },
+  });
+  await assert.rejects(
+    () => auth.discover(),
+    (error) => error.code === 'accounts_unreachable' && /network, DNS, or TLS/.test(error.message),
+  );
+});
+
+test('Accounts discovery identifies incompatible metadata', async () => {
+  const auth = new AccountsDeviceAuth({ fetchImpl: async () => response({ ...discovery, issuer: 'https://invalid.example' }) });
+  await assert.rejects(
+    () => auth.discover(),
+    (error) => error.code === 'invalid_accounts_metadata' && /incompatible/.test(error.message),
+  );
+});
+
+test('Lixrl login configuration retries a transient server failure', async () => {
+  let calls = 0;
+  const result = await fetchLixrlCliConfig({
+    apiUrl: 'https://lixrl.com',
+    retries: 1,
+    sleep: async () => {},
+    fetchImpl: async () => {
+      calls += 1;
+      if (calls === 1) return response({ error: 'busy' }, 503);
+      return response({
+        client_id: 'registered-client-id',
+        accounts_origin: 'https://accounts.elixpo.com',
+        audience: 'lixrl.com',
+      });
+    },
+  });
+  assert.equal(result.clientId, 'registered-client-id');
+  assert.equal(calls, 2);
+});
+
 test('device polling keeps pending responses separate from returned tokens', async () => {
   const queue = [
     response(discovery),

--- a/packages/lixrl-cli/tests/invocation.test.mjs
+++ b/packages/lixrl-cli/tests/invocation.test.mjs
@@ -28,3 +28,10 @@ test('valid commands pass preflight validation', () => {
   assert.equal(validateInvocation('qr', 'https://example.com', [], {}), undefined);
   assert.equal(validateInvocation('whoami', undefined, [], {}), undefined);
 });
+
+test('login rejects conflicting key selection before credential lookup', () => {
+  assert.throws(
+    () => validateInvocation('login', undefined, [], { key: true, 'new-key': true }),
+    (error) => error.code === 'invalid_usage' && /either --key or --new-key/.test(error.message),
+  );
+});

--- a/packages/lixrl-cli/tests/ui.test.mjs
+++ b/packages/lixrl-cli/tests/ui.test.mjs
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { colorEnabled, failureBlock, loginChallenge, statusLine, withSpinner } from '../src/ui.js';
+import { colorEnabled, failureBlock, loginChallenge, parseLoginChoice, statusLine, withSpinner } from '../src/ui.js';
 
 test('device login displays the prefilled verification URL without requiring color', () => {
   const output = loginChallenge({
@@ -19,6 +19,15 @@ test('device login displays the prefilled verification URL without requiring col
 test('NO_COLOR disables terminal styling', () => {
   assert.equal(colorEnabled({ isTTY: true }, { NO_COLOR: '1', TERM: 'xterm' }), false);
   assert.equal(colorEnabled({ isTTY: true }, { TERM: 'xterm' }), true);
+});
+
+test('login choice accepts new-key defaults and existing-key aliases', () => {
+  assert.equal(parseLoginChoice(''), 'new');
+  assert.equal(parseLoginChoice('1'), 'new');
+  assert.equal(parseLoginChoice('create'), 'new');
+  assert.equal(parseLoginChoice('2'), 'existing');
+  assert.equal(parseLoginChoice('paste'), 'existing');
+  assert.equal(parseLoginChoice('invalid'), null);
 });
 
 test('terminal statuses use distinct symbols and colors', () => {


### PR DESCRIPTION
## Summary

- reuse a verified local profile before starting any new authorization
- let interactive users choose a new key or paste an existing raw key
- add `--new-key` and reject conflicting key-selection flags early
- retry safe Lixrl configuration and Accounts discovery requests
- replace the generic outage message with timeout, connectivity, HTTP, and metadata errors
- document why dashboard keys cannot be recovered after creation

## Verification

- `git diff --check`
- Added coverage for retry behavior, safe diagnostics, login choice parsing, and flag conflicts
- Package tests were not run locally because Node/npm are unavailable in this execution environment

Fixes #73
