### PR TITLE
fix: resolve missing CI secret and add edge architecture diagram

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -211,6 +211,7 @@ jobs:
       CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
       CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
       RUN_MIGRATIONS: ${{ needs.changes.outputs.migrations }}
+      SOPS_AGE_KEY: ${{ secrets.SOPS_AGE_KEY }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/README.md
+++ b/README.md
@@ -83,6 +83,37 @@ Other projects include [Elixpo Blogs](https://blogs.elixpo.com),
 [Elixpo Search](https://search.elixpo.com), and
 [Elixpo Accounts](https://accounts.elixpo.com).
 
+## Edge Architecture
+
+Lixrl relies on a Cloudflare Worker acting as a subdomain router at the edge. The following high-level diagram illustrates how incoming short link requests are intercepted, validated against user entitlements, and resolved via a fast KV cache or D1 database before silently logging analytics.
+
+```mermaid
+sequenceDiagram
+    participant C as Client
+    participant W as Worker (fetch)
+    participant D1 as D1 Database
+    participant KV as KV Cache
+    participant A as Worker (trackClick)
+
+    C->>W: GET http://[label].lixrl.com/[code]
+    W->>D1: Query Domain & User Entitlement
+    alt Invalid/Inactive
+        W-->>C: 404 Not Found
+    else .well-known challenge
+        W-->>C: 200 { verified: true }
+    else Valid Request
+        W->>KV: Get Cached Redirect
+        alt Cache Miss
+            W->>D1: Query Redirect Record
+            W->>KV: Put Redirect Record
+        end
+        W-->>C: 302 Redirect to Original URL
+        Note over W,A: Analytics (ctx.waitUntil)
+        W->>A: Spawn trackClick()
+        A->>D1: Update clicks & Insert click record
+    end
+```
+
 ## Built in the open
 
 Lixrl is shaped by contributors and its users. You can report a problem,


### PR DESCRIPTION
### Summary
This PR addresses two independent issues in the repository:
1. **Fixes #66:** Adds the missing `SOPS_AGE_KEY` to the `pages` job environment in `.github/workflows/deploy.yml` so that `deploy.sh migrate` can successfully decrypt SOPS secrets.
2. **Fixes #65:** Adds a Mermaid high-level sequence diagram to `README.md` documenting the Edge Cloudflare Worker architecture (subdomain routing, KV caching, D1 queries, and background analytics).

### Checklist for #66 (SOPS_AGE_KEY)
- [x] Confirmed `SOPS_AGE_KEY` was missing from the `pages` job environment.
- [x] Added `SOPS_AGE_KEY: ${{ secrets.SOPS_AGE_KEY }}` directly to the job's `env:` block.
- ⚠️ **Maintainer Action Required:** I cannot verify if the `SOPS_AGE_KEY` secret has actually been created in the GitHub repository or `production` environment settings. A maintainer will need to confirm the secret exists before this will work in production.

### Checklist for #65 (Edge Architecture Diagram)
- [x] Studied the actual request flow in `workers/subdomain-router.ts`.
- [x] Created an accurate sequence diagram outlining the exact process (Domain/Entitlement validation -> KV Cache check -> D1 queries -> Background `trackClick` analytics via `ctx.waitUntil`).
- [x] Validated that the Mermaid syntax is correct and renders natively on GitHub.
- [x] Inserted the diagram into `README.md` under a new "Edge Architecture" section.
